### PR TITLE
Some improvements, and additions for 2022

### DIFF
--- a/calibrations.py
+++ b/calibrations.py
@@ -1,6 +1,7 @@
 # Utility to add calibrations
 # git clone ssh://git@gitlab.cern.ch:7999/cms-nanoAOD/jsonpog-integration.git
 
+import os
 import ROOT
 import correctionlib
 correctionlib.register_pyroot_binding()
@@ -62,14 +63,25 @@ computeTightBTAGSF = '''
 '''
 
 def btag_init(year):
-    sfDir = '/isilon/data/users/mstamenk/hhh-6b-producer/CMSSW_12_5_2/src/jsonpog-integration/POG/BTV/%s_UL/btagging.json.gz'%year
+    if year in ['2016APV', '2016', '2017', '2018']:
+        sfDir = os.path.join(os.environ["CMSSW_BASE"], 'src/jsonpog-integration/POG/BTV/%s_UL/btagging.json.gz'%year)
+    elif year == '2022':
+        sfDir = os.path.join(os.environ["CMSSW_BASE"], 'src/jsonpog-integration/POG/BTV/2022_Summer22/btagging.json.gz')
+    elif year == '2022EE':
+        sfDir = os.path.join(os.environ["CMSSW_BASE"], 'src/jsonpog-integration/POG/BTV/2022_Summer22EE/btagging.json.gz')
     ROOT.gInterpreter.Declare('auto btvjson = correction::CorrectionSet::from_file("%s");'%sfDir)
-    ROOT.gInterpreter.Declare('auto btvjson_shape = btvjson->at("deepJet_shape");')
-    ROOT.gInterpreter.Declare('auto btvjson_comb = btvjson->at("deepJet_comb");') # bc
-    ROOT.gInterpreter.Declare('auto btvjson_incl = btvjson->at("deepJet_incl");') # light
-    ROOT.gInterpreter.Declare(computeLooseBTAGSF)
-    ROOT.gInterpreter.Declare(computeMediumBTAGSF)
-    ROOT.gInterpreter.Declare(computeTightBTAGSF)
+    if year in ['2016APV', '2016', '2017', '2018']:
+        ROOT.gInterpreter.Declare('auto btvjson_shape = btvjson->at("deepJet_shape");')
+        ROOT.gInterpreter.Declare('auto btvjson_comb = btvjson->at("deepJet_comb");') # bc
+        ROOT.gInterpreter.Declare('auto btvjson_incl = btvjson->at("deepJet_incl");') # light
+        ROOT.gInterpreter.Declare(computeLooseBTAGSF)
+        ROOT.gInterpreter.Declare(computeMediumBTAGSF)
+        ROOT.gInterpreter.Declare(computeTightBTAGSF)
+    elif year in ['2022', '2022EE']:
+        # No SFs available yet; just WPs
+        ROOT.gInterpreter.Declare('float computeLooseBTagsEffSFPerFlavour(int hadronFlavour, float eta, float pt){return 1.0;}')
+        ROOT.gInterpreter.Declare('float computeMediumBTagsEffSFPerFlavour(int hadronFlavour, float eta, float pt){return 1.0;}')
+        ROOT.gInterpreter.Declare('float computeTightBTagsEffSFPerFlavour(int hadronFlavour, float eta, float pt){return 1.0;}')
 
 
 

--- a/draw_data_mc_categories.py
+++ b/draw_data_mc_categories.py
@@ -35,7 +35,7 @@ output_folder=options.output_folder
 if output_folder == "none" :
     output_folder = input_folder
 
-for era in ['2016APV', '2016', '2017', '2018' ] :
+for era in ['2016APV', '2016', '2017', '2018', '2022', '2022EE'] :
     if era in input_folder : year = era
 
 labels = addLabel_CMS_preliminary(luminosities[year])

--- a/hhh_variables.py
+++ b/hhh_variables.py
@@ -112,6 +112,19 @@ def add_hhh_variables_resolved(df):
         drs.append(dr)
     return df,masses,pts,etas,phis,drs
 
+def add_missing_variables():
+    # Missing variables for Run3
+    added = []
+    for i in range(len(unique)):
+        perm = unique[i]
+        j1,j2 = perm
+        if j1 not in added:
+            added.append(j1)
+            ROOT.gInterpreter.Declare('float %sbRegCorr = 1.0;'%j1)
+        if j2 not in added:
+            added.append(j2)
+            ROOT.gInterpreter.Declare('float %sbRegCorr = 1.0;'%j2)
+
 
 
 

--- a/machinelearning.py
+++ b/machinelearning.py
@@ -24,6 +24,7 @@ bdts_xml_boosted = {
             }
 
 def init_bdt(df, year):
+    if year not in bdts_xml: return
     xmlpath_odd, xmlpath_even = bdts_xml[year]
 
     ROOT.gInterpreter.ProcessLine('''TMVA::Experimental::RReader model_even("{}");'''.format(xmlpath_even))
@@ -56,6 +57,7 @@ def init_bdt(df, year):
 
 
 def add_bdt(df, year):
+    if year not in bdts_xml: return df
     xmlpath_odd, xmlpath_even = bdts_xml[year]
 
 
@@ -93,6 +95,7 @@ def add_bdt(df, year):
 
 
 def init_bdt_boosted(df, year): # need to initialise once so that it doesnt create memory issues for multiple processes in for loop
+    if year not in bdts_xml_boosted: return
     xmlpath_odd, xmlpath_even = bdts_xml_boosted[year]
 
     ROOT.gInterpreter.ProcessLine('''TMVA::Experimental::RReader model_even_boosted("{}");'''.format(xmlpath_even))
@@ -126,6 +129,7 @@ def init_bdt_boosted(df, year): # need to initialise once so that it doesnt crea
     #df = df.Define('mvaBoosted', 'computeModelBoosted(%s)'%method_call)
 
 def add_bdt_boosted(df, year):
+    if year not in bdts_xml_boosted: return df
     xmlpath_odd, xmlpath_even = bdts_xml_boosted[year]
 
     #ROOT.gInterpreter.ProcessLine('''TMVA::Experimental::RReader model_even_boosted("{}");'''.format(xmlpath_even))

--- a/prepare_inclusive_samples_weights.py
+++ b/prepare_inclusive_samples_weights.py
@@ -8,7 +8,7 @@ from machinelearning import init_bdt_boosted, add_bdt_boosted, init_bdt, add_bdt
 from utils import init_mhhh, addMHHH, initialise_df,triggersCorrections, save_variables, matching_variables, hlt_paths
 from calibrations import btag_init, addBTagSF, addBTagEffSF
 
-from hhh_variables import add_hhh_variables, add_hhh_variables_resolved
+from hhh_variables import add_hhh_variables, add_hhh_variables_resolved, add_missing_variables
 
 ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.ROOT.EnableImplicitMT()
@@ -17,7 +17,9 @@ import argparse
 parser = argparse.ArgumentParser(description='Args')
 parser.add_argument('-v','--version', default='v28')
 parser.add_argument('--year', default='2018')
-parser.add_argument('--f_in', default = 'GluGluToHHHTo6B_SM')
+parser.add_argument('--f_in', default='') # GluGluToHHHTo6B_SM
+parser.add_argument('--path', default='/isilon/data/users/mstamenk/hhh-6b-producer/CMSSW_11_1_0_pre5_PY3/src/PhysicsTools/NanoAODTools/condor/')
+parser.add_argument('--output', default='/isilon/data/users/mstamenk/eos-triple-h/')
 args = parser.parse_args()
 
 version = args.version
@@ -27,11 +29,11 @@ year = args.year
 
 #path = '/isilon/data/users/mstamenk/eos-triple-h/samples-%s-%s-spanet-boosted-variables-nanoaod'%(version,year)
 #path = '/isilon/data/users/mstamenk/eos-triple-h/samples-%s-%s-nanoaod'%(version,year)
-path = '/isilon/data/users/mstamenk/hhh-6b-producer/CMSSW_11_1_0_pre5_PY3/src/PhysicsTools/NanoAODTools/condor/%s_ak8_option4_%s/*/parts/'%(version,year)
+path = os.path.join(args.path, '%s_ak8_option4_%s'%(version,year), '*', 'parts')
 
 print(path)
 
-output = '/isilon/data/users/mstamenk/eos-triple-h/%s-parts-no-lhe/mva-inputs-%s/'%(version,year)
+output = os.path.join(args.output, '%s-parts-no-lhe'%version, 'mva-inputs-%s'%year)
 
 
 inclusive_resolved = 'inclusive_resolved-weights'
@@ -53,6 +55,7 @@ if not os.path.isdir(output + '/' + inclusive_boosted):
     os.makedirs(output + '/' + inclusive_boosted)
 
 files = glob.glob(path + '/' + '*.root')
+if args.f_in!='': files = [args.f_in]
 
 first = True
 
@@ -61,7 +64,7 @@ init_mhhh()
 
 if '2016' in year:
     ROOT.gInterpreter.Declare(triggersCorrections['2016'][0])
-else:
+elif '2022' not in year: # TODO: No SFs yet for 2022/2022EE
     ROOT.gInterpreter.Declare(triggersCorrections[year][0])
 
 if '2016APV' in year:
@@ -76,116 +79,117 @@ if '2017' in year:
 else:
     data_files = ['JetHT.root']
 
-#for f_in in files:
+for f_in in files:
 
-f_in = args.f_in
-f_name = os.path.basename(f_in)
-print(f_name)
+    f_name = os.path.basename(f_in)
+    print(f_name)
 
-df = ROOT.RDataFrame('Events',f_in)
+    df = ROOT.RDataFrame('Events',f_in)
 
-print(path+'/'+f_name)
-#df = ROOT.RDataFrame('Events',f_in)
-#if 'BTagCSV' in f_name:
+    print(path+'/'+f_name)
+    #df = ROOT.RDataFrame('Events',f_in)
+    #if 'BTagCSV' in f_name:
 
-cmd = '''
-    Bool_t get_false(){return 0;}
-'''
+    cmd = '''
+        Bool_t get_false(){return 0;}
+    '''
 
-ROOT.gInterpreter.Declare(cmd)
+    ROOT.gInterpreter.Declare(cmd)
 
-list_inputs = [str(el) for el in df.GetColumnNames() ]
-if 'HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2' not in list_inputs:
-    df = df.Define('HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2','get_false()')
-if 'HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1' not in list_inputs:
-    df = df.Define('HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1','get_false()')
-if 'HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1' not in list_inputs:
-    df = df.Define('HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1','get_false()')
-if 'HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2' not in list_inputs:   
-    df = df.Define('HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2','get_false()')
-if 'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1' not in list_inputs:
-    df = df.Define('HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1','get_false()')
-if 'HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2' not in list_inputs:
-    df = df.Define('HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2','get_false()')
-if 'HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94' not in list_inputs:
-    df = df.Define('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94','get_false()')
-if 'HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59' not in list_inputs:
-    df = df.Define('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59','get_false()')
+    list_inputs = [str(el) for el in df.GetColumnNames() ]
+    if 'HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2' not in list_inputs:
+        df = df.Define('HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2','get_false()')
+    if 'HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1' not in list_inputs:
+        df = df.Define('HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1','get_false()')
+    if 'HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1' not in list_inputs:
+        df = df.Define('HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1','get_false()')
+    if 'HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2' not in list_inputs:   
+        df = df.Define('HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2','get_false()')
+    if 'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1' not in list_inputs:
+        df = df.Define('HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1','get_false()')
+    if 'HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2' not in list_inputs:
+        df = df.Define('HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2','get_false()')
+    if 'HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94' not in list_inputs:
+        df = df.Define('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94','get_false()')
+    if 'HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59' not in list_inputs:
+        df = df.Define('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59','get_false()')
 
-if 'HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4' not in list_inputs:
-    df = df.Define('HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4','get_false()')
+    if 'HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4' not in list_inputs:
+        df = df.Define('HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4','get_false()')
 
-if 'HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17' not in list_inputs:
-    df = df.Define('HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17','get_false()')
+    if 'HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17' not in list_inputs:
+        df = df.Define('HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17','get_false()')
 
-if 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1' not in list_inputs:
-    df = df.Define('HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1','get_false()')
+    if 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1' not in list_inputs:
+        df = df.Define('HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1','get_false()')
 
-if 'HLT_AK8PFJet330_PFAK8BTagCSV_p17' not in list_inputs:
-    df = df.Define('HLT_AK8PFJet330_PFAK8BTagCSV_p17','get_false()')
+    if 'HLT_AK8PFJet330_PFAK8BTagCSV_p17' not in list_inputs:
+        df = df.Define('HLT_AK8PFJet330_PFAK8BTagCSV_p17','get_false()')
 
-if 'HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0' not in list_inputs:
-    df = df.Define('HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0','get_false()')
-
-
-if 'HLT_AK8PFHT750_TrimMass50' not in list_inputs:
-    df = df.Define('HLT_AK8PFHT750_TrimMass50','get_false()')
-if 'HLT_AK8PFJet400_TrimMass30' not in list_inputs:
-    df = df.Define('HLT_AK8PFJet400_TrimMass30','get_false()')
-if 'HLT_AK8PFJet360_TrimMass30' not in list_inputs:
-    df = df.Define('HLT_AK8PFJet360_TrimMass30','get_false()')
-if 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1' not in list_inputs:
-    df = df.Define('HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1','get_false()')
-
-if 'HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2' not in list_inputs:
-    df = df.Define('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2','get_false()')
-if 'HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2' not in list_inputs:
-    df = df.Define('HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2','get_false()')
-
-if 'HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5' not in list_inputs:
-    df = df.Define('HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5','get_false()')
+    if 'HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0' not in list_inputs:
+        df = df.Define('HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0','get_false()')
 
 
-if 'HLT_AK8PFJet450' not in list_inputs:
-    df = df.Define('HLT_AK8PFJet450','get_false()')
+    if 'HLT_AK8PFHT750_TrimMass50' not in list_inputs:
+        df = df.Define('HLT_AK8PFHT750_TrimMass50','get_false()')
+    if 'HLT_AK8PFJet400_TrimMass30' not in list_inputs:
+        df = df.Define('HLT_AK8PFJet400_TrimMass30','get_false()')
+    if 'HLT_AK8PFJet360_TrimMass30' not in list_inputs:
+        df = df.Define('HLT_AK8PFJet360_TrimMass30','get_false()')
+    if 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1' not in list_inputs:
+        df = df.Define('HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1','get_false()')
 
-hlt = hlt_paths[year]
-df = df.Filter(hlt)
+    if 'HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2' not in list_inputs:
+        df = df.Define('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2','get_false()')
+    if 'HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2' not in list_inputs:
+        df = df.Define('HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2','get_false()')
 
-if first:
-    init_bdt(df,year)
-    init_bdt_boosted(df,year)
-    first = False
+    if 'HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5' not in list_inputs:
+        df = df.Define('HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5','get_false()')
 
-df = initialise_df(df,year,f_in)
 
-df,masses,pts,etas,phis,drs = add_hhh_variables_resolved(df)
+    if 'HLT_AK8PFJet450' not in list_inputs:
+        df = df.Define('HLT_AK8PFJet450','get_false()')
 
-df = add_bdt(df,year)
-df = add_bdt_boosted(df,year)
-if 'JetHT' not in f_in and 'BTagCSV' not in f_in and 'SingleMuon' not in f_in:
-    df = matching_variables(df)
+    hlt = hlt_paths[year]
+    df = df.Filter(hlt)
 
-#df = df.Define('ProbMultiH','ProbHHH + ProbHH4b + ProbHHH4b2tau + ProbHH2b2tau')
+    if first:
+        init_bdt(df,year)
+        init_bdt_boosted(df,year)
+        first = False
 
-df_resolved = df.Filter(cut_resolved)
-df_boosted = df.Filter(cut_boosted)
+    df = initialise_df(df,year,f_in)
 
-print("Running on %s"%f_in)
-print("Doing resolved")
+    if "2022" in year:
+        add_missing_variables()
+    df,masses,pts,etas,phis,drs = add_hhh_variables_resolved(df)
 
-#to_save = [str(el) for el in df_boosted.GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'PNet' not in str(el)]
-to_save = [str(el) for el in df_boosted.GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'LHE' not in str(el)]
-print(to_save)
-print(len(to_save))
-#if not os.path.isfile( output + '/' + inclusive_resolved + '/' + f_name):
-#df_resolved.Snapshot('Events', output + '/' + inclusive_resolved + '/' + f_name, to_save)
-print("Doing boosted")
+    df = add_bdt(df,year)
+    df = add_bdt_boosted(df,year)
+    if 'JetHT' not in f_in and 'BTagCSV' not in f_in and 'SingleMuon' not in f_in:
+        df = matching_variables(df)
 
-#if not os.path.isfile( output + '/' + inclusive_boosted + '/' + f_name):
-#print(save_variables + ['eventWeight']+masses+pts+etas+phis+drs)
+    #df = df.Define('ProbMultiH','ProbHHH + ProbHH4b + ProbHHH4b2tau + ProbHH2b2tau')
 
-df_boosted.Snapshot('Events', output + '/' + inclusive_boosted + '/' + f_name, to_save)
+    df_resolved = df.Filter(cut_resolved)
+    df_boosted = df.Filter(cut_boosted)
+
+    print("Running on %s"%f_in)
+    print("Doing resolved")
+
+    #to_save = [str(el) for el in df_boosted.GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'PNet' not in str(el)]
+    to_save = [str(el) for el in df_boosted.GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'LHE' not in str(el)]
+    print(to_save)
+    print(len(to_save))
+    #if not os.path.isfile( output + '/' + inclusive_resolved + '/' + f_name):
+    #df_resolved.Snapshot('Events', output + '/' + inclusive_resolved + '/' + f_name, to_save)
+    print("Doing boosted")
+
+    #if not os.path.isfile( output + '/' + inclusive_boosted + '/' + f_name):
+    #print(save_variables + ['eventWeight']+masses+pts+etas+phis+drs)
+
+    df_boosted.Snapshot('Events', output + '/' + inclusive_boosted + '/' + f_name, to_save)
 
 
 print("All done!")

--- a/prepare_inclusive_samples_weights.py
+++ b/prepare_inclusive_samples_weights.py
@@ -5,7 +5,7 @@ import os, ROOT
 import glob
 
 from machinelearning import init_bdt_boosted, add_bdt_boosted, init_bdt, add_bdt
-from utils import init_mhhh, addMHHH, initialise_df,triggersCorrections, save_variables, matching_variables, hlt_paths
+from utils import init_mhhh, addMHHH, initialise_df,triggersCorrections, save_variables, matching_variables, hlt_paths, GetAllTriggers
 from calibrations import btag_init, addBTagSF, addBTagEffSF
 
 from hhh_variables import add_hhh_variables, add_hhh_variables_resolved, add_missing_variables
@@ -35,24 +35,20 @@ print(path)
 
 output = os.path.join(args.output, '%s-parts-no-lhe'%version, 'mva-inputs-%s'%year)
 
+cutlist = {
+    "inclusive": ['inclusive-weights', '1.0'],
+    "combined": ['inclusive_combined-weights', '(nprobejets > 0) || (nprobetaus > 0) || (nsmalljets >= 2) || (ntaus >= 2)'],
+    #"resolved": ['inclusive_resolved-weights', 'nsmalljets >= 4 && nprobejets == 0'],
+    #"boosted": ['inclusive_boosted-weights', '(nprobejets > 0) || (nprobetaus > 0) || (nsmalljets >= 4 && nprobejets == 0 && nloosebtags >= 4) || (nsmalljets >= 2 && nprobejets == 0 && nloosebtags >= 2 && ntaus>=2)']
+}
 
-inclusive_resolved = 'inclusive_resolved-weights'
-inclusive_boosted = 'inclusive-weights'
-#inclusive_boosted = 'inclusive_boosted'
-
-cut_resolved = 'nsmalljets >= 4 && nprobejets == 0'
-#cut_boosted = 'nprobejets > 0 '
-cut_boosted = '(nprobejets > 0) || (nsmalljets >= 4 && nprobejets == 0 && nloosebtags >= 4)'
 
 #cut_boosted = '(nprobejets > -1)'
 
-if not os.path.isdir(output + '/' + inclusive_resolved):
-    print("Creating %s"%(output + '/' + inclusive_resolved))
-    os.makedirs(output + '/' + inclusive_resolved)
-
-if not os.path.isdir(output + '/' + inclusive_boosted):
-    print("Creating %s"%(output + '/' + inclusive_boosted))
-    os.makedirs(output + '/' + inclusive_boosted)
+for cut in cutlist:
+    if not os.path.isdir(output + '/' + cutlist[cut][0]):
+        print("Creating %s"%(output + '/' + cutlist[cut][0]))
+        os.makedirs(output + '/' + cutlist[cut][0])
 
 files = glob.glob(path + '/' + '*.root')
 if args.f_in!='': files = [args.f_in]
@@ -79,6 +75,7 @@ if '2017' in year:
 else:
     data_files = ['JetHT.root']
 
+inited = False
 for f_in in files:
 
     f_name = os.path.basename(f_in)
@@ -94,63 +91,20 @@ for f_in in files:
         Bool_t get_false(){return 0;}
     '''
 
-    ROOT.gInterpreter.Declare(cmd)
+    if not inited:
+        ROOT.gInterpreter.Declare(cmd)
 
     list_inputs = [str(el) for el in df.GetColumnNames() ]
-    if 'HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2' not in list_inputs:
-        df = df.Define('HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2','get_false()')
-    if 'HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1' not in list_inputs:
-        df = df.Define('HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1','get_false()')
-    if 'HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1' not in list_inputs:
-        df = df.Define('HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1','get_false()')
-    if 'HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2' not in list_inputs:   
-        df = df.Define('HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2','get_false()')
-    if 'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1' not in list_inputs:
-        df = df.Define('HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1','get_false()')
-    if 'HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2' not in list_inputs:
-        df = df.Define('HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2','get_false()')
-    if 'HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94' not in list_inputs:
-        df = df.Define('HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94','get_false()')
-    if 'HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59' not in list_inputs:
-        df = df.Define('HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59','get_false()')
-
-    if 'HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4' not in list_inputs:
-        df = df.Define('HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4','get_false()')
-
-    if 'HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17' not in list_inputs:
-        df = df.Define('HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17','get_false()')
-
-    if 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1' not in list_inputs:
-        df = df.Define('HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1','get_false()')
-
-    if 'HLT_AK8PFJet330_PFAK8BTagCSV_p17' not in list_inputs:
-        df = df.Define('HLT_AK8PFJet330_PFAK8BTagCSV_p17','get_false()')
-
-    if 'HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0' not in list_inputs:
-        df = df.Define('HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0','get_false()')
-
-
-    if 'HLT_AK8PFHT750_TrimMass50' not in list_inputs:
-        df = df.Define('HLT_AK8PFHT750_TrimMass50','get_false()')
-    if 'HLT_AK8PFJet400_TrimMass30' not in list_inputs:
-        df = df.Define('HLT_AK8PFJet400_TrimMass30','get_false()')
-    if 'HLT_AK8PFJet360_TrimMass30' not in list_inputs:
-        df = df.Define('HLT_AK8PFJet360_TrimMass30','get_false()')
-    if 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1' not in list_inputs:
-        df = df.Define('HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1','get_false()')
-
-    if 'HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2' not in list_inputs:
-        df = df.Define('HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2','get_false()')
-    if 'HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2' not in list_inputs:
-        df = df.Define('HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2','get_false()')
-
-    if 'HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5' not in list_inputs:
-        df = df.Define('HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5','get_false()')
-
-
-    if 'HLT_AK8PFJet450' not in list_inputs:
-        df = df.Define('HLT_AK8PFJet450','get_false()')
-
+    #MustHaveTriggers = ['HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2', 'HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1', 'HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1', 'HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2', 'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1', 'HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2', 'HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94', 'HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59', 'HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4', 'HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17', 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1', 'HLT_AK8PFJet330_PFAK8BTagCSV_p17', 'HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0', 'HLT_AK8PFHT750_TrimMass50', 'HLT_AK8PFJet400_TrimMass30', 'HLT_AK8PFJet360_TrimMass30', 'HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1', 'HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2', 'HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2', 'HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5', 'HLT_AK8PFJet450']
+    # Do we need all a branch for all triggers of all years?
+    MustHaveTriggers = GetAllTriggers()
+    MustHaveTriggers = [trig for y in MustHaveTriggers for trig in MustHaveTriggers[y]]
+    MustHaveTriggers = list(dict.fromkeys(MustHaveTriggers))
+    # Or just ensure we have all for the corresponding era?
+    #MustHaveTriggers = [trig for trig in GetAllTriggers[year]]
+    for trig in MustHaveTriggers:
+        if trig not in list_inputs:
+            df = df.Define(trig,'get_false()')
     hlt = hlt_paths[year]
     df = df.Filter(hlt)
 
@@ -161,8 +115,9 @@ for f_in in files:
 
     df = initialise_df(df,year,f_in)
 
-    if "2022" in year:
+    if "2022" in year and not inited:
         add_missing_variables()
+    inited = True
     df,masses,pts,etas,phis,drs = add_hhh_variables_resolved(df)
 
     df = add_bdt(df,year)
@@ -172,24 +127,25 @@ for f_in in files:
 
     #df = df.Define('ProbMultiH','ProbHHH + ProbHH4b + ProbHHH4b2tau + ProbHH2b2tau')
 
-    df_resolved = df.Filter(cut_resolved)
-    df_boosted = df.Filter(cut_boosted)
+    dfs = {}
+    for cut in cutlist:
+        dfs[cut] = df.Filter(cutlist[cut][1])
 
     print("Running on %s"%f_in)
-    print("Doing resolved")
-
     #to_save = [str(el) for el in df_boosted.GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'PNet' not in str(el)]
-    to_save = [str(el) for el in df_boosted.GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'LHE' not in str(el)]
-    print(to_save)
-    print(len(to_save))
-    #if not os.path.isfile( output + '/' + inclusive_resolved + '/' + f_name):
-    #df_resolved.Snapshot('Events', output + '/' + inclusive_resolved + '/' + f_name, to_save)
-    print("Doing boosted")
 
-    #if not os.path.isfile( output + '/' + inclusive_boosted + '/' + f_name):
+    for cut in cutlist:
+        print("Doing", cut, "for", f_name)
+        if os.path.isfile( output + '/' + cutlist[cut][0] + '/' + f_name): continue
+
+        to_save = [str(el) for el in dfs[cut].GetColumnNames() if 'L1_' not in str(el) and 'v_' not in str(el) and 'MassRegressed' not in str(el) and 'bcand' not in str(el) and 'boostedTau_' not in str(el) and 'LHE' not in str(el)]
+        print(to_save)
+        print(len(to_save))
+
+        dfs[cut].Snapshot('Events', output + '/' + cutlist[cut][0] + '/' + f_name, to_save)
+
+
     #print(save_variables + ['eventWeight']+masses+pts+etas+phis+drs)
-
-    df_boosted.Snapshot('Events', output + '/' + inclusive_boosted + '/' + f_name, to_save)
 
 
 print("All done!")

--- a/skimm_tree.py
+++ b/skimm_tree.py
@@ -21,14 +21,14 @@ import gc
 ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.ROOT.EnableImplicitMT()
 
-from utils import histograms_dict, wps_years, wps, tags, luminosities, hlt_paths, triggersCorrections, hist_properties, init_mhhh, addMHHH, clean_variables, initialise_df, save_variables, init_get_max_prob, init_get_max_cat
+from utils import histograms_dict, wps_years, tags, luminosities, hlt_paths, triggersCorrections, hist_properties, init_mhhh, addMHHH, clean_variables, initialise_df, save_variables, init_get_max_prob, init_get_max_cat
 from machinelearning import init_bdt, add_bdt, init_bdt_boosted, add_bdt_boosted
 from calibrations import btag_init, addBTagSF, addBTagEffSF
 from hhh_variables import add_hhh_variables
 
 from optparse import OptionParser
 parser = OptionParser()
-parser.add_option("--base_folder ", type="string", dest="base", help="Folder in where to look for the categories", default='/isilon/data/users/mstamenk/eos-triple-h/v27-spanet-boosted-classification-variables/mva-inputs-2018/')
+parser.add_option("--base_folder ", type="string", dest="base", help="Folder in where to look for the categories", default='/eos/user/d/dmroy/HHH/ntuples/v27-spanet-boosted-variables/mva-inputs-2018/')
 parser.add_option("--category ", type="string", dest="category", help="Category to compute it. if no argument is given will do all", default='none')
 parser.add_option("--skip_do_trees", action="store_true", dest="skip_do_trees", help="Write...", default=False)
 parser.add_option("--skip_do_histograms", action="store_true", dest="skip_do_histograms", help="Write...", default=False)
@@ -37,6 +37,7 @@ parser.add_option("--do_SR", action="store_true", dest="do_SR", help="Write...",
 parser.add_option("--do_CR", action="store_true", dest="do_CR", help="Write...", default=False)
 parser.add_option("--process ", type="string", dest="process_to_compute", help="Process to compute it. if no argument is given will do all", default='none')
 parser.add_option("--do_limit_input ", type="string", dest="do_limit_input", help="If given it will do the histograms only in that variable with all the uncertainties", default='none')
+parser.add_option("--year", type="string", dest="year", help="What year is this", default='')
 ## separate SR_CR as an option, this option would add _SR and _CR to the subfolder name
 ## add option to enter a process and if that is given to make the trees and histos only to it
 ## add option to add BDT computation here -- or not, we leave this only to MVA input variables -- the prefit plots already do data/MC
@@ -51,6 +52,7 @@ skip_do_histograms = options.skip_do_histograms
 skip_do_plots      = options.skip_do_plots
 input_tree         = options.base
 cat                = options.category
+year               = options.year
 
 if do_SR and do_CR :
     print("You should chose to signal region OR control region")
@@ -1053,9 +1055,10 @@ if not process_to_compute == 'none' :
     procstodo     = [process_to_compute]
     skip_do_plots = True
 
-for era in ['2016APV', '2016', '2017', '2018','2016APV201620172018'] :
-#for era in [2018] :
-    if str(era) in input_tree : year = str(era)
+if year=='':
+    for era in ['2016APV', '2016', '2017', '2018','2016APV201620172018', '2022', '2022EE'] :
+    #for era in [2018] :
+        if str(era) in input_tree : year = str(era)
 
 if '2016APV201620172018' in year:
     year = '2018'
@@ -1121,7 +1124,9 @@ for selection in selections.keys() :
     outtree = "{}/{}_{}/{}.root".format(input_tree,selection,additional_label,proctodo)
 
     dataset = selections[selection]["dataset"] # inclusive_resolved or inclusive_boosted
-    list_proc=glob.glob("{}/inclusive{}/{}.root".format(input_tree,dataset,datahist))
+    subdir = "inclusive"+dataset if dataset.startswith("-") else "inclusive_"+dataset
+    list_proc=glob.glob(os.path.join(input_tree, subdir, datahist+"*.root"))
+    if list_proc == []: continue
     print("Will create %s" % outtree)
 
 

--- a/skimm_tree.py
+++ b/skimm_tree.py
@@ -1121,7 +1121,7 @@ for selection in selections.keys() :
         else:
             datahist = 'BTagCSV'
 
-    outtree = "{}/{}_{}/{}.root".format(input_tree,selection,additional_label,proctodo)
+    outtree = os.path.join(input_tree, selection+"_"+additional_label, proctodo+".root")
 
     dataset = selections[selection]["dataset"] # inclusive_resolved or inclusive_boosted
     subdir = "inclusive"+dataset if dataset.startswith("-") else "inclusive_"+dataset
@@ -1137,7 +1137,13 @@ for selection in selections.keys() :
         print(current_time)
         seconds0 = time.time()
         print(proc)
-        print("Cutting tree and saving it to ", outtree)
+        varregex = r'_part[0-9_]+.root'
+        part = re.findall(varregex, proc)
+        if part!=[]:
+            thisouttree = outtree.replace(".root", part[0])
+        else:
+            thisouttree = outtree
+        print("Cutting tree and saving it to ", thisouttree)
         print("With selection: ", final_selection)
 
         chunk_df = ROOT.RDataFrame(inputTree, proc)
@@ -1251,7 +1257,7 @@ for selection in selections.keys() :
         #chunk_df.Snapshot(inputTree, outtree, variables + ['totalWeight'])
         to_save = [str(el) for el in chunk_df.GetColumnNames() if 'mva' not in str(el)]
 
-        chunk_df.Snapshot(inputTree, outtree,to_save)
+        chunk_df.Snapshot(inputTree, thisouttree,to_save)
 
         gc.collect() # clean menory
         sys.stdout.flush() # extra clean

--- a/spanet-inference/condor-slurm/prepare_jobs.py
+++ b/spanet-inference/condor-slurm/prepare_jobs.py
@@ -3,40 +3,68 @@
 import os, glob  
 import ROOT
 import math
+import cppyy
+
+# Hardcoded inputs:
+years = ['2018']
+version = 'v31-merged-selection-no-lhe'
+regime = 'inclusive-weights'
+mainpath = '/users/mstamenk/scratch/mstamenk'
+
+# Consistent with default paths in both scripts:
+scripts = {0: 'predict_spanet_classification_pnet_all_vars.py', 1: 'predict_spanet_classification_categorisation.py'}
+inputdir = 'mva-inputs-%s'
+outputdir1 = 'mva-inputs-%s-spanet-boosted-classification'
+outputdir2 = 'mva-inputs-%s-categorisation-spanet-boosted-classification'
+
+years = ['2022']
+version = 'v2022'
+mainpath = '/eos/user/d/dmroy/HHH/sampleProduction/TestOutput/'
 
 
-current_path = '/users/mstamenk/hhh-analysis-framework/spanet-inference/'
-#script = current_path + '/' + 'predict_spanet_classification_pnet_all_vars.py'
-script = current_path + '/' + 'predict_spanet_classification_categorisation.py'
 
-pwd = current_path + '/' + 'condor-slurm/'
+
+scripts = {i: os.path.join(os.environ["CMSSW_BASE"], 'src/hhh-analysis-framework/spanet-inference', scripts[i]) for i in scripts}
+filedirs = {0: inputdir, 1: outputdir1, 2: outputdir2}
+pwd = os.path.join(os.environ["CMSSW_BASE"], 'src/hhh-analysis-framework/spanet-inference', 'condor-slurm')
 jobs_path = 'jobs'
 
-submit="Universe   = vanilla\nrequest_memory = 7900\nExecutable = %s\nArguments  = $(ClusterId) $(ProcId)\nLog        = log/job_%s_%s_%s.log\nOutput     = output/job_%s_%s_%s.out\nError      = error/job_%s_%s_%s.error\nQueue 1"
+#submit="Universe   = vanilla\nrequest_memory = 7900\nExecutable = %s\nArguments  = $(ClusterId) $(ProcId)\nLog        = log/job_%s_%s_%s.log\nOutput     = output/job_%s_%s_%s.out\nError      = error/job_%s_%s_%s.error\nQueue 1"
+submit="Universe   = vanilla\nrequest_memory = 2000\nExecutable = %s\nArguments  = $(ClusterId) $(ProcId)\nLog        = log/job_%s_%s_%s.log\nOutput     = output/job_%s_%s_%s.out\nError      = error/job_%s_%s_%s.error\nQueue 1"
+submit_lxplus='universe              = vanilla\nexecutable            = %s\narguments             = $(ProcId)\nlog                   = log/job_%s_$(ClusterId).log\noutput                = output/job_%s_$(ClusterId).$(ProcId).out\nerror                 = error/job_%s_$(ClusterId).$(ProcId).err\ngetenv                = true\n\n+JobFlavour = "longlunch"\nRequestCpus = 4\n\nqueue %s'
 job_cmd = '#! /bin/bash\n#SBATCH -p batch\n#SBATCH -n 1\n#SBATCH -t 03:00:00\n#SBATCH --mem=24g\n%s\nexit'
+job_cmd_lxplus = '#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nfunction peval { echo ">>> $@"; eval "$@"; }\nWORKDIR="$PWD"\nif [ ! -z "$CMSSW_BASE" -a -d "$CMSSW_BASE/src" ]; then\n  peval "cd $CMSSW_BASE/src"\n  peval "eval `scramv1 runtime -sh`"\n  peval "cd $WORKDIR"\nfi\nsource /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_102 x86_64-centos7-gcc11-opt\n\n'
 #job_cmd = '%s'
 
 
 submit_all = 'submit_all.sh'
+submit_all_lxplus = 'submit_all_lxplus.sh'
 manual_all = 'manual_run_all.sh'
 
 jobs = []
+jobs_lxp = []
 manual_jobs = []
-#for year in ['2016','2016APV','2017','2018']:
 
-year = '2018'
-version = 'v31-parts-no-lhe'
 
+def WriteFile(path, content):
+    print("Writing %s"%os.path.join(jobs_path, os.path.basename(path)))
+    with open(path, 'w') as f:
+        f.write(content)
 
 regime = 'inclusive-weights'
 batch_size = 50e3
-#for year in ['2016','2016APV','2017','2018']:
-for year in ['2018']:
+for year in years:
     #path_to_samples = '/users/mstamenk/scratch/mstamenk//samples-%s-%s-nanoaod/'%(version,year)
-    path_to_samples = '/users/mstamenk/scratch/mstamenk//%s/mva-inputs-%s/%s/'%(version,year,regime)
-    files = glob.glob(path_to_samples+'*.root')
+    #path_to_samples = '/users/mstamenk/scratch/mstamenk//%s/mva-inputs-%s/%s/'%(version,year,regime)
+    #path_to_samples = '/eos/user/d/dmroy/HHH/sampleProduction/TestOutput/mva-inputs-%s/%s/'%(year,regime)
+    path_to_samples = os.path.join(mainpath, version, inputdir%(year), regime)
+    files = glob.glob(os.path.join(path_to_samples, '*.root'))
     #files = [f for f in files if 'TTToSemi' in f or 'W' in f or 'Z' in f]
     samples = [os.path.basename(s).replace('.root','') for s in files]
+    jobcount = 0
+    job_cmd_lxplus_full = job_cmd_lxplus
+    print(samples)
+    print(files)
     for i in range(len(files)):
         f_in = samples[i]
         f = files[i]
@@ -44,45 +72,77 @@ for year in ['2018']:
         entries = df.Count().GetValue()
         n_batches = math.floor(float(entries)/batch_size)
         for j in range(n_batches+1):
-            filename = 'job_%s_%s_%d.sh'%(f_in,year,j)
-            cmd = 'python3 %s --f_in %s --year %s --batch_size %d --batch_number %d --version %s'%(script,f_in,year,batch_size,j,version)
+            # Check if previous jobs completed
+            script = ""
+            for k in [0,1]:
+                expoutfile = f.replace(inputdir%(year), filedirs[k+1]%(year)).replace('.root', '_%d.root'%j)
+                print(expoutfile)
+                if os.path.isfile(expoutfile):
+                    try:
+                        df = ROOT.RDataFrame("Events", expoutfile)
+                        entries = df.Count().GetValue()
+                        if entries > 0: continue # If output file exists and has valid content, move on
+                    except cppyy.gbl.std.runtime_error:
+                        pass
+                script = scripts[k]
+                break
+            if script=="": continue
 
-            print("Writing %s"%filename)
-            with open(jobs_path + '/' + filename, 'w') as f:
-                f.write(job_cmd%cmd)
+            filename = 'job_%s_%s_%d.sh'%(f_in,year,j)
+            cmd = 'python3 %s --f_in %s --year %s --batch_size %d --batch_number %d --version %s --regime %s --path %s'%(script,f_in,year,batch_size,j,version,regime,mainpath)
+            print(cmd)
+
+            WriteFile(os.path.join(jobs_path, filename), job_cmd%cmd)
             manual_jobs.append(filename)
 
+            job_cmd_lxplus_full += 'if [ $1 -eq %d ]; then\n  %s\nfi\n\n'%(jobcount,cmd)
+            jobcount += 1
+
             submit_file = 'submit_%s_%s_%s'%(f_in,year,j)
-            print('Writing %s/%s'%(jobs_path, submit_file))
-            with open(jobs_path + '/' + submit_file, 'w') as f:
-                f.write(submit%(jobs_path+'/'+filename,f_in,year,j,f_in,year,j,f_in,year,j))
+            WriteFile(os.path.join(jobs_path, submit_file), submit%(os.path.join(jobs_path,filename),f_in,year,j,f_in,year,j,f_in,year,j))
             jobs.append(submit_file)
+
+    if jobcount>0:
+        filename_lxp = 'job_%s_lxplus.sh'%(year)
+        WriteFile(os.path.join(jobs_path, filename_lxp), job_cmd_lxplus_full)
+
+        submit_file_lxp = 'submit_%s_lxplus.sub'%(year)
+        WriteFile(os.path.join(jobs_path, submit_file_lxp), submit_lxplus%(os.path.join(jobs_path,filename_lxp),year,year,year,jobcount))
+        jobs_lxp.append(submit_file_lxp)
+    else:
+        print("ALL JOBS DONE FOR",year,"!")
 
 cmd = '#!/bin/bash\n'
 for j in jobs:
-    cmd += 'condor_submit %s/%s \n'%(jobs_path, j)
-
+    cmd += 'condor_submit %s \n'%(os.path.join(jobs_path, j))
 
 with open(submit_all, 'w') as f:
+    f.write(cmd)
+
+cmd = '#!/bin/bash\n'
+for j in jobs_lxp:
+    cmd += 'condor_submit %s \n'%(os.path.join(jobs_path, j))
+
+with open(submit_all_lxplus, 'w') as f:
     f.write(cmd)
 
 if len(manual_jobs) > 1000:
     cmd1 = '#!/bin/bash\n'
     for f in manual_jobs[:999]:
-        cmd1+= 'sbatch %s/%s/%s\n'%(pwd,jobs_path,f)
+        cmd1+= 'sbatch %s\n'%(os.path.join(pwd,jobs_path,f))
     with open(manual_all,'w') as f:
         f.write(cmd1)
 
     cmd2 =  '#!/bin/bash\n'
     for f in manual_jobs[999:]:
-        cmd2+= 'sbatch %s/%s/%s\n'%(pwd,jobs_path,f)
+        cmd2+= 'sbatch %s\n'%(os.path.join(pwd,jobs_path,f))
     with open(manual_all.replace('.sh','_2.sh'), 'w') as f:
         f.write(cmd2)
 
 else:
     cmd = '#!/bin/bash\n'
     for f in manual_jobs:
-        cmd += 'sbatch %s/%s/%s\n'%(pwd,jobs_path,f)
+        cmd += 'sbatch %s\n'%(os.path.join(pwd,jobs_path,f))
 
     with open(manual_all,'w') as f:
         f.write(cmd)

--- a/spanet-inference/merge_samples.py
+++ b/spanet-inference/merge_samples.py
@@ -7,16 +7,19 @@ import argparse
 parser = argparse.ArgumentParser(description='Args')
 parser.add_argument('-v','--version', default='v28-QCD-modelling') # version of NanoNN production
 parser.add_argument('--year', default='2018') # year
+parser.add_argument('--typename', default='categorisation-spanet-boosted-classification') # typename
+parser.add_argument('--regime', default='inclusive-weights') # regime
+parser.add_argument('--inpath',default = '/users/mstamenk/scratch/mstamenk')
+parser.add_argument('--outpath',default = '/users/mstamenk/scratch/mstamenk/eos-triple-h')
 args = parser.parse_args()
 
 year = args.year
 version = args.version
-typename = 'spanet-boosted-classification'
+typename = args.typename
+regime = args.regime
 
-regime = 'inclusive-weights'
-path = '/users/mstamenk/scratch/mstamenk/%s/mva-inputs-%s-%s/%s/'%(version,year,typename,regime)
-
-files = glob.glob(path +'/*.root')
+path = os.path.join(args.inpath, version, 'mva-inputs-%s-%s'%(year,typename), regime)
+files = glob.glob(os.path.join(path, '*.root'))
 
 #files = [f for f in files if 'HHH' in f or 'HH' in f]
 
@@ -46,13 +49,13 @@ samples = list(set(samples))
 
 print(samples)
 
-output_path = '/users/mstamenk/scratch/mstamenk/eos-triple-h/%s-merged-selection/mva-inputs-%s-%s/%s/'%(version,year,typename,regime)
+output_path = os.path.join(args.outpath, '%s-merged-selection'%version, 'mva-inputs-%s-%s'%(year,typename), regime)
 
 if not os.path.isdir(output_path):
     os.makedirs(output_path)
 
 for sample in samples:
-    cmd = 'hadd -f -j -n 0 %s/%s.root %s/%s_*.root'%(output_path,sample,path,sample)
+    cmd = 'hadd -f -j -n 0 %s %s'%(os.path.join(output_path, '%s.root'%sample),os.path.join(path,'%s_*.root'%sample))
     print(cmd)
     #if 'QCD' in sample and "bEnriched" not in sample: continue
     #if 'TTToSemiLeptonic' in sample: continue

--- a/spanet-inference/merge_samples_v2.py
+++ b/spanet-inference/merge_samples_v2.py
@@ -1,0 +1,68 @@
+import os, glob
+
+
+
+# argument parser
+import argparse
+parser = argparse.ArgumentParser(description='Args')
+parser.add_argument('-v','--version', default='v28-QCD-modelling') # version of NanoNN production
+parser.add_argument('--year', default='2018') # year
+parser.add_argument('--typename', default='categorisation-spanet-boosted-classification') # typename
+parser.add_argument('--regime', default='inclusive-weights') # regime
+parser.add_argument('--inpath',default = '/users/mstamenk/scratch/mstamenk')
+parser.add_argument('--outpath',default = '/users/mstamenk/scratch/mstamenk/eos-triple-h')
+parser.add_argument('--outsize',default = 1.0) # Maximum output filesize in GB
+args = parser.parse_args()
+
+year = args.year
+version = args.version
+typename = args.typename
+regime = args.regime
+outsize = args.outsize * 1024 # MB
+
+path = os.path.join(args.inpath, version, 'mva-inputs-%s-%s'%(year,typename), regime)
+files = glob.glob(os.path.join(path, '*.root'))
+
+samples = {}
+sizes = {}
+
+for f in files:
+    sample = os.path.basename(f)
+    splits = sample.split('_tree_')
+
+    sample_type = splits[0]
+    if sample_type not in samples:
+        samples[sample_type] = []
+        sizes[sample_type] = []
+    samples[sample_type].append(f)
+    sizes[sample_type].append(float(os.path.getsize(f))/1024/1024) # MB
+
+#print(samples)
+
+output_path = os.path.join(args.outpath, '%s-merged-selection'%version, 'mva-inputs-%s-%s'%(year,typename), regime)
+
+if not os.path.isdir(output_path):
+    os.makedirs(output_path)
+
+for sample in samples:
+    fullsize = sum(sizes[sample])
+    noutputs = int(fullsize / outsize)+1
+
+    i = 0
+    part = 0
+    while i<len(samples[sample]):
+        tohadd = []
+        tohadd.append(i)
+        i+=1
+        while i<len(samples[sample]):
+            if sum([sizes[sample][j] for j in tohadd]) + sizes[sample][i] < outsize:
+                tohadd.append(i)
+                i+=1
+            else:
+                break
+        part+=1
+        partstr = "_part"+str(part)
+        if part==1 and i==len(samples[sample]): partstr=""
+        cmd = f'hadd -f -j -n 0 {os.path.join(output_path, sample+partstr+".root")} {" ".join([samples[sample][j] for j in tohadd])}'
+        print(">>> "+cmd)
+        os.system(cmd)

--- a/spanet-inference/predict_spanet_classification_categorisation.py
+++ b/spanet-inference/predict_spanet_classification_categorisation.py
@@ -340,7 +340,7 @@ MET_data = np.transpose(met_arrays, (1,0,2))
 MET_mask = MET_data[:,:,0] > 0
 
 HT_data = np.transpose(ht_arrays, (1,0,2))
-HT_mask = MET_data[:,:,0] > 0
+HT_mask = HT_data[:,:,0] > 0
 
 Jet1_data = np.transpose(Jets_arrays['Jet1'],(1,0,2))
 Jet1_Mass = Jet1_data[:,:,0]

--- a/spanet-inference/predict_spanet_classification_pnet_all_vars.py
+++ b/spanet-inference/predict_spanet_classification_pnet_all_vars.py
@@ -154,6 +154,7 @@ path_f_in = os.path.join(path, '%s.root'%args.f_in)
 
 df = ROOT.RDataFrame("Events", path_f_in)
 entries = df.Count().GetValue()
+allnames = df.GetColumnNames()
 
 event_min = int(args.batch_size) * int(args.batch_number)
 event_max = event_min + int(args.batch_size)
@@ -278,7 +279,8 @@ ht_arrays.append(np_arr)
 jet_4vec = ["%sPt", "%sEta","%sPhi","%sMass","%sHiggsMatchedIndex"]
 array_4vec = []
 for i in ['1','2','3','4','5','6','7','8','9','10']:
-    column_4vec = [el%'jet%s'%i for el in jet_4vec]
+    column_4vec = [el%'jet%s'%i for el in jet_4vec if el%'jet%s'%i in allnames]
+    isMC = (len(column_4vec)==5)
     np_4vec = df.AsNumpy(column_4vec)
     np_arr_4vec = np.vstack(np_4vec[col] for col in column_4vec).T
     array_4vec.append(np_arr_4vec)
@@ -289,7 +291,7 @@ for i in range(len(array_4vec[0])):
     for j in range(10):
         jet = ROOT.TLorentzVector()
         jet.SetPtEtaPhiM(array_4vec[j][i][0], array_4vec[j][i][1], array_4vec[j][i][2], array_4vec[j][i][3])
-        jet.HiggsMatchedIndex = array_4vec[j][i][4]
+        if isMC: jet.HiggsMatchedIndex = array_4vec[j][i][4]
         jets_tmp.append(jet)
     jets.append(jets_tmp)
 
@@ -297,7 +299,7 @@ for i in range(len(array_4vec[0])):
 fatjet_4vec = ["%sPt", "%sEta","%sPhi","%sMass","%sHiggsMatchedIndex"]
 array_fj_4vec = []
 for i in ['1','2','3']:
-    column_4vec = [el%'fatJet%s'%i for el in jet_4vec]
+    column_4vec = [el%'fatJet%s'%i for el in jet_4vec if el%'fatJet%s'%i in allnames]
     np_4vec = df.AsNumpy(column_4vec)
     np_arr_4vec = np.vstack(np_4vec[col] for col in column_4vec).T
     array_fj_4vec.append(np_arr_4vec)
@@ -308,7 +310,7 @@ for i in range(len(array_fj_4vec[0])):
     for j in range(3):
         jet = ROOT.TLorentzVector()
         jet.SetPtEtaPhiM(array_4vec[j][i][0], array_4vec[j][i][1], array_4vec[j][i][2], array_4vec[j][i][3])
-        jet.HiggsMatchedIndex = array_4vec[j][i][4]
+        if isMC: jet.HiggsMatchedIndex = array_4vec[j][i][4]
         jets_tmp.append(jet)
     fatjets.append(jets_tmp)
 
@@ -451,52 +453,58 @@ for i in range(len(output_values[0])):
 
     if len(h1_index) == 2:
         h1 = jets_tmp[int(h1_index[0])] + jets_tmp[int(h1_index[1])]
-        if jets_tmp[int(h1_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h1_index[1])].HiggsMatchedIndex and jets_tmp[int(h1_index[1])].HiggsMatchedIndex > 0:
-          h1.HiggsMatchedIndex = jets_tmp[int(h1_index[0])].HiggsMatchedIndex
-        else:
-          h1.HiggsMatchedIndex = -1
         h1_j1idx.append(float(int(h1_index[0])))
         h1_j2idx.append(float(int(h1_index[1])))
         h1_fatidx.append(float(-1))
+        if isMC: 
+          if jets_tmp[int(h1_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h1_index[1])].HiggsMatchedIndex and jets_tmp[int(h1_index[1])].HiggsMatchedIndex > 0:
+            h1.HiggsMatchedIndex = jets_tmp[int(h1_index[0])].HiggsMatchedIndex
+          else:
+            h1.HiggsMatchedIndex = -1
     elif len(h1_index) == 3:
         h1 = fjets_tmp[int(h1_index)-110]
-        h1.HiggsMatchedIndex = fjets_tmp[int(h1_index)-110].HiggsMatchedIndex # > 0
         h1_j1idx.append(float(-1))
         h1_j2idx.append(float(-1))
         h1_fatidx.append(float(int(h1_index)-110))
+        if isMC:
+          h1.HiggsMatchedIndex = fjets_tmp[int(h1_index)-110].HiggsMatchedIndex # > 0
 
 
     if len(h2_index) == 2:
         h2 = jets_tmp[int(h2_index[0])] + jets_tmp[int(h2_index[1])]
-        if jets_tmp[int(h2_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h2_index[1])].HiggsMatchedIndex and jets_tmp[int(h2_index[1])].HiggsMatchedIndex > 0:
-          h2.HiggsMatchedIndex = jets_tmp[int(h2_index[0])].HiggsMatchedIndex
-        else:
-          h2.HiggsMatchedIndex = -1
         h2_j1idx.append(float(int(h2_index[0])))
         h2_j2idx.append(float(int(h2_index[1])))
         h2_fatidx.append(float(-1))
+        if isMC:
+          if jets_tmp[int(h2_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h2_index[1])].HiggsMatchedIndex and jets_tmp[int(h2_index[1])].HiggsMatchedIndex > 0:
+            h2.HiggsMatchedIndex = jets_tmp[int(h2_index[0])].HiggsMatchedIndex
+          else:
+            h2.HiggsMatchedIndex = -1
     elif len(h2_index) == 3:
         h2 = fjets_tmp[int(h2_index)-110]
-        h2.HiggsMatchedIndex = fjets_tmp[int(h2_index)-110].HiggsMatchedIndex # > 0
         h2_j1idx.append(float(-1))
         h2_j2idx.append(float(-1))
         h2_fatidx.append(float(int(h2_index)-110))
+        if isMC:
+          h2.HiggsMatchedIndex = fjets_tmp[int(h2_index)-110].HiggsMatchedIndex # > 0
 
     if len(h3_index) == 2:
         h3 = jets_tmp[int(h3_index[0])] + jets_tmp[int(h3_index[1])]
-        if jets_tmp[int(h3_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h3_index[1])].HiggsMatchedIndex and jets_tmp[int(h3_index[1])].HiggsMatchedIndex > 0:
-          h3.HiggsMatchedIndex = jets_tmp[int(h3_index[0])].HiggsMatchedIndex
-        else:
-          h3.HiggsMatchedIndex = -1
         h3_j1idx.append(float(int(h3_index[0])))
         h3_j2idx.append(float(int(h3_index[1])))
         h3_fatidx.append(float(-1))
+        if isMC:
+          if jets_tmp[int(h3_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h3_index[1])].HiggsMatchedIndex and jets_tmp[int(h3_index[1])].HiggsMatchedIndex > 0:
+            h3.HiggsMatchedIndex = jets_tmp[int(h3_index[0])].HiggsMatchedIndex
+          else:
+            h3.HiggsMatchedIndex = -1
     elif len(h3_index) == 3:
         h3 = fjets_tmp[int(h3_index)-110]
-        h3.HiggsMatchedIndex = fjets_tmp[int(h3_index)-110].HiggsMatchedIndex # > 0
         h3_j1idx.append(float(-1))
         h3_j2idx.append(float(-1))
         h3_fatidx.append(float(int(h3_index)-110))
+        if isMC:
+          h3.HiggsMatchedIndex = fjets_tmp[int(h3_index)-110].HiggsMatchedIndex # > 0
 
     higgses = [h1,h2,h3]
     #higgses.sort(key= lambda x: x.Pt(), reverse=True)
@@ -520,9 +528,10 @@ for i in range(len(output_values[0])):
     h3_eta.append(h3.Eta())
     h3_phi.append(h3.Phi())
 
-    h1_match.append(float(h1.HiggsMatchedIndex))
-    h2_match.append(float(h2.HiggsMatchedIndex))
-    h3_match.append(float(h3.HiggsMatchedIndex))
+    if isMC:
+        h1_match.append(float(h1.HiggsMatchedIndex))
+        h2_match.append(float(h2.HiggsMatchedIndex))
+        h3_match.append(float(h3.HiggsMatchedIndex))
 
     prob_hhh.append(float(output_values[12][i][1])) # based on mapping in SPANET training
     prob_qcd.append(float(output_values[12][i][2]))

--- a/spanet-inference/predict_spanet_classification_pnet_all_vars.py
+++ b/spanet-inference/predict_spanet_classification_pnet_all_vars.py
@@ -340,7 +340,7 @@ MET_data = np.transpose(met_arrays, (1,0,2))
 MET_mask = MET_data[:,:,0] > 0
 
 HT_data = np.transpose(ht_arrays, (1,0,2))
-HT_mask = MET_data[:,:,0] > 0
+HT_mask = HT_data[:,:,0] > 0
 
 Jet1_data = np.transpose(Jets_arrays['Jet1'],(1,0,2))
 Jet1_Mass = Jet1_data[:,:,0]
@@ -406,6 +406,16 @@ h1_match = []
 h2_match = []
 h3_match = []
 
+h1_j1idx = []
+h1_j2idx = []
+h1_fatidx = []
+h2_j1idx = []
+h2_j2idx = []
+h2_fatidx = []
+h3_j1idx = []
+h3_j2idx = []
+h3_fatidx = []
+
 prob_hhh = [] # 1
 prob_qcd = [] # 2
 prob_tt = [] # 3
@@ -441,25 +451,52 @@ for i in range(len(output_values[0])):
 
     if len(h1_index) == 2:
         h1 = jets_tmp[int(h1_index[0])] + jets_tmp[int(h1_index[1])]
-        h1.HiggsMatchedIndex = jets_tmp[int(h1_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h1_index[1])].HiggsMatchedIndex and jets_tmp[int(h1_index[1])].HiggsMatchedIndex > 0
+        if jets_tmp[int(h1_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h1_index[1])].HiggsMatchedIndex and jets_tmp[int(h1_index[1])].HiggsMatchedIndex > 0:
+          h1.HiggsMatchedIndex = jets_tmp[int(h1_index[0])].HiggsMatchedIndex
+        else:
+          h1.HiggsMatchedIndex = -1
+        h1_j1idx.append(float(int(h1_index[0])))
+        h1_j2idx.append(float(int(h1_index[1])))
+        h1_fatidx.append(float(-1))
     elif len(h1_index) == 3:
         h1 = fjets_tmp[int(h1_index)-110]
-        h1.HiggsMatchedIndex = fjets_tmp[int(h1_index)-110].HiggsMatchedIndex > 0
+        h1.HiggsMatchedIndex = fjets_tmp[int(h1_index)-110].HiggsMatchedIndex # > 0
+        h1_j1idx.append(float(-1))
+        h1_j2idx.append(float(-1))
+        h1_fatidx.append(float(int(h1_index)-110))
 
 
     if len(h2_index) == 2:
         h2 = jets_tmp[int(h2_index[0])] + jets_tmp[int(h2_index[1])]
-        h2.HiggsMatchedIndex = jets_tmp[int(h2_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h2_index[1])].HiggsMatchedIndex and jets_tmp[int(h2_index[1])].HiggsMatchedIndex > 0
+        if jets_tmp[int(h2_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h2_index[1])].HiggsMatchedIndex and jets_tmp[int(h2_index[1])].HiggsMatchedIndex > 0:
+          h2.HiggsMatchedIndex = jets_tmp[int(h2_index[0])].HiggsMatchedIndex
+        else:
+          h2.HiggsMatchedIndex = -1
+        h2_j1idx.append(float(int(h2_index[0])))
+        h2_j2idx.append(float(int(h2_index[1])))
+        h2_fatidx.append(float(-1))
     elif len(h2_index) == 3:
         h2 = fjets_tmp[int(h2_index)-110]
-        h2.HiggsMatchedIndex = fjets_tmp[int(h2_index)-110].HiggsMatchedIndex > 0
+        h2.HiggsMatchedIndex = fjets_tmp[int(h2_index)-110].HiggsMatchedIndex # > 0
+        h2_j1idx.append(float(-1))
+        h2_j2idx.append(float(-1))
+        h2_fatidx.append(float(int(h2_index)-110))
 
     if len(h3_index) == 2:
         h3 = jets_tmp[int(h3_index[0])] + jets_tmp[int(h3_index[1])]
-        h3.HiggsMatchedIndex = jets_tmp[int(h3_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h3_index[1])].HiggsMatchedIndex and jets_tmp[int(h3_index[1])].HiggsMatchedIndex > 0
+        if jets_tmp[int(h3_index[0])].HiggsMatchedIndex ==  jets_tmp[int(h3_index[1])].HiggsMatchedIndex and jets_tmp[int(h3_index[1])].HiggsMatchedIndex > 0:
+          h3.HiggsMatchedIndex = jets_tmp[int(h3_index[0])].HiggsMatchedIndex
+        else:
+          h3.HiggsMatchedIndex = -1
+        h3_j1idx.append(float(int(h3_index[0])))
+        h3_j2idx.append(float(int(h3_index[1])))
+        h3_fatidx.append(float(-1))
     elif len(h3_index) == 3:
-        h3 = fjets_tmp[int(h2_index)-110]
-        h3.HiggsMatchedIndex = fjets_tmp[int(h3_index)-110].HiggsMatchedIndex > 0
+        h3 = fjets_tmp[int(h3_index)-110]
+        h3.HiggsMatchedIndex = fjets_tmp[int(h3_index)-110].HiggsMatchedIndex # > 0
+        h3_j1idx.append(float(-1))
+        h3_j2idx.append(float(-1))
+        h3_fatidx.append(float(int(h3_index)-110))
 
     higgses = [h1,h2,h3]
     #higgses.sort(key= lambda x: x.Pt(), reverse=True)
@@ -483,9 +520,9 @@ for i in range(len(output_values[0])):
     h3_eta.append(h3.Eta())
     h3_phi.append(h3.Phi())
 
-    h1_match.append(int(h1.HiggsMatchedIndex))
-    h2_match.append(int(h2.HiggsMatchedIndex))
-    h3_match.append(int(h3.HiggsMatchedIndex))
+    h1_match.append(float(h1.HiggsMatchedIndex))
+    h2_match.append(float(h2.HiggsMatchedIndex))
+    h3_match.append(float(h3.HiggsMatchedIndex))
 
     prob_hhh.append(float(output_values[12][i][1])) # based on mapping in SPANET training
     prob_qcd.append(float(output_values[12][i][2]))
@@ -516,19 +553,27 @@ arr_h1_pt = ROOT.VecOps.AsRVec(np.array(h1_pt))
 arr_h1_eta = ROOT.VecOps.AsRVec(np.array(h1_eta))
 arr_h1_phi = ROOT.VecOps.AsRVec(np.array(h1_phi))
 arr_h1_match = ROOT.VecOps.AsRVec(np.array(h1_match))
-
+arr_h1_j1idx = ROOT.VecOps.AsRVec(np.array(h1_j1idx))
+arr_h1_j2idx = ROOT.VecOps.AsRVec(np.array(h1_j2idx))
+arr_h1_fatidx = ROOT.VecOps.AsRVec(np.array(h1_fatidx))
 
 arr_h2_mass = ROOT.VecOps.AsRVec(np.array(h2_mass))
 arr_h2_pt = ROOT.VecOps.AsRVec(np.array(h2_pt))
 arr_h2_eta = ROOT.VecOps.AsRVec(np.array(h2_eta))
 arr_h2_phi = ROOT.VecOps.AsRVec(np.array(h2_phi))
 arr_h2_match = ROOT.VecOps.AsRVec(np.array(h2_match))
+arr_h2_j1idx = ROOT.VecOps.AsRVec(np.array(h2_j1idx))
+arr_h2_j2idx = ROOT.VecOps.AsRVec(np.array(h2_j2idx))
+arr_h2_fatidx = ROOT.VecOps.AsRVec(np.array(h2_fatidx))
 
 arr_h3_mass = ROOT.VecOps.AsRVec(np.array(h3_mass))
 arr_h3_pt = ROOT.VecOps.AsRVec(np.array(h3_pt))
 arr_h3_eta = ROOT.VecOps.AsRVec(np.array(h3_eta))
 arr_h3_phi = ROOT.VecOps.AsRVec(np.array(h3_phi))
 arr_h3_match = ROOT.VecOps.AsRVec(np.array(h3_match))
+arr_h3_j1idx = ROOT.VecOps.AsRVec(np.array(h3_j1idx))
+arr_h3_j2idx = ROOT.VecOps.AsRVec(np.array(h3_j2idx))
+arr_h3_fatidx = ROOT.VecOps.AsRVec(np.array(h3_fatidx))
 
 arr_prob_hhh = ROOT.VecOps.AsRVec(np.array(prob_hhh))
 arr_prob_qcd = ROOT.VecOps.AsRVec(np.array(prob_qcd))
@@ -558,19 +603,31 @@ df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_mass, "h1_spanet_boosted_mass")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_pt, "h1_spanet_boosted_pt")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_eta, "h1_spanet_boosted_eta")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_phi, "h1_spanet_boosted_phi")
-df = ROOT.AddBoolArray(ROOT.RDF.AsRNode(df), arr_h1_match, "h1_spanet_boosted_match")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_match, "h1_spanet_boosted_match")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_j1idx, "h1_spanet_jet1idx")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_j2idx, "h1_spanet_jet2idx")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h1_fatidx, "h1_spanet_fatjetidx")
+#df = ROOT.AddBoolArray(ROOT.RDF.AsRNode(df), arr_h1_match, "h1_spanet_boosted_match")
 
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_mass, "h2_spanet_boosted_mass")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_pt, "h2_spanet_boosted_pt")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_eta, "h2_spanet_boosted_eta")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_phi, "h2_spanet_boosted_phi")
-df = ROOT.AddBoolArray(ROOT.RDF.AsRNode(df), arr_h2_match, "h2_spanet_boosted_match")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_match, "h2_spanet_boosted_match")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_j1idx, "h2_spanet_jet1idx")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_j2idx, "h2_spanet_jet2idx")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h2_fatidx, "h2_spanet_fatjetidx")
+#df = ROOT.AddBoolArray(ROOT.RDF.AsRNode(df), arr_h2_match, "h2_spanet_boosted_match")
 
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_mass, "h3_spanet_boosted_mass")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_pt, "h3_spanet_boosted_pt")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_eta, "h3_spanet_boosted_eta")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_phi, "h3_spanet_boosted_phi")
-df = ROOT.AddBoolArray(ROOT.RDF.AsRNode(df), arr_h3_match, "h3_spanet_boosted_match")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_match, "h3_spanet_boosted_match")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_j1idx, "h3_spanet_jet1idx")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_j2idx, "h3_spanet_jet2idx")
+df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_h3_fatidx, "h3_spanet_fatjetidx")
+#df = ROOT.AddBoolArray(ROOT.RDF.AsRNode(df), arr_h3_match, "h3_spanet_boosted_match")
 
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_prob_hhh, "ProbHHH")
 df = ROOT.AddArray(ROOT.RDF.AsRNode(df), arr_prob_qcd, "ProbQCD")

--- a/utils.py
+++ b/utils.py
@@ -16,10 +16,41 @@ luminosities = {#'2016' : 36330.0,
                 '2022EE' : 26340.0,
         }
 
-
-# Nice list to construct "hlt_paths", "hlt_sf_20XX" and "hlt_method_20XX" from.
-# Currently only made for 2018/2022/2022EE
-AllHLTsWithSFs = {
+def GetAllTriggers():
+  # Nice list to construct "hlt_paths", "hlt_sf_20XX" and "hlt_method_20XX" from.
+  AllHLTsWithSFs = {
+    '2016': {
+        'HLT_QuadJet45_TripleBTagCSV_p087': 36.47/36.47,
+        'HLT_PFHT400_SixJet30_DoubleBTagCSV_p056': 1.0,
+        'HLT_PFHT450_SixJet40_BTagCSV_p056': 1.0,
+        'HLT_AK8PFJet360_TrimMass30': 1.0,
+        'HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20': 1.0,
+        'HLT_AK8PFJet450': 33.64/36.47,
+        'HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200': 25.36/36.47,
+        'HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq460': 25.36/36.47,
+        'HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20': 20.20/36.47,
+        'HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20': 20.20/36.47,
+        'HLT_PFJet450': 16.94/36.47,
+        'HLT_PFMET120_BTagCSV_p067': 16.94/36.47,
+        'HLT_QuadJet45_DoubleBTagCSV_p087': 1.29/36.47,
+    },
+    '2017': {
+        'HLT_PFJet450': 10.45/41.48,
+        'HLT_PFJet500': 1.0,
+        'HLT_PFHT1050': 1.0,
+        'HLT_AK8PFJet550': 1.0,
+        'HLT_AK8PFJet360_TrimMass30': 28.23/41.48,
+        'HLT_AK8PFJet400_TrimMass30': 36.67/41.48,
+        'HLT_AK8PFHT750_TrimMass50': 30.90/41.48,
+        'HLT_AK8PFJet330_PFAK8BTagCSV_p17': 7.73/41.48,
+        'HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0': 36.67/41.48,
+        'HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1': 28.23/41.48,
+        'HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2': 5.30/41.48,
+        'HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2': 17.68/41.48,
+        'HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5': 5.30/41.48,
+        'HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1': 5.30/41.48,
+        'HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2': 7.73/41.48,
+    },
     '2018': {
         'HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5': 1.0,
         'HLT_PFHT1050': 1.0,
@@ -53,22 +84,43 @@ AllHLTsWithSFs = {
         'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepJet_1p3_7p7_VBF1': 1.0,
         'HLT_QuadPFJet98_83_71_15_PFBTagDeepJet_1p3_VBF2': 1.0,
         'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1': 1.0,
+        # Tau-Tau:
+        'HLT_DoubleMediumDeepTauPFTauHPS35_L2NN_eta2p1': 1.0,
+        'HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1': 1.0,
+        'HLT_DoublePFJets40_Mass500_MediumDeepTauPFTauHPS45_L2NN_MediumDeepTauPFTauHPS20_eta2p1': 1.0,
+        'HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60': 1.0,
+        'HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet75': 1.0,
+        # Mu-Tau:
+        'HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1': 1.0,
+        # El-Tau:
+        'HLT_Ele24_eta2p1_WPTight_Gsf_LooseDeepTauPFTauHPS30_eta2p1_CrossL1': 1.0,
+        # El-Mu:
+        'HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ': 1.0, 
+        'HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ': 1.0,
+
     }
-}
-AllHLTsWithSFs['2022EE'] = AllHLTsWithSFs['2022']
+  }
+  AllHLTsWithSFs['2016APV'] = AllHLTsWithSFs['2016']
+  AllHLTsWithSFs['2022EE'] = AllHLTsWithSFs['2022']
+  return AllHLTsWithSFs
+
+AllHLTsWithSFs = GetAllTriggers()
 
 
 hlt_paths = {
-       '2016' : '( HLT_QuadJet45_TripleBTagCSV_p087||  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056||  HLT_PFHT450_SixJet40_BTagCSV_p056||  HLT_AK8PFJet360_TrimMass30||  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20||  HLT_AK8PFJet450||  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200||  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20||  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20||  HLT_PFJet450 ||  HLT_QuadJet45_DoubleBTagCSV_p087 )',
+       #'2016' : '( HLT_QuadJet45_TripleBTagCSV_p087||  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056||  HLT_PFHT450_SixJet40_BTagCSV_p056||  HLT_AK8PFJet360_TrimMass30||  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20||  HLT_AK8PFJet450||  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200||  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20||  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20||  HLT_PFJet450 ||  HLT_QuadJet45_DoubleBTagCSV_p087 )',
         #'2016' : '( HLT_QuadJet45_TripleBTagCSV_p087 || HLT_DoubleJet90_Double30_TripleBTagCSV_p087)',
         #'2016PostAPV' : '( HLT_QuadJet45_TripleBTagCSV_p087 || HLT_DoubleJet90_Double30_TripleBTagCSV_p087)',
-        '2016APV' : '( HLT_QuadJet45_TripleBTagCSV_p087||  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056||  HLT_PFHT450_SixJet40_BTagCSV_p056||  HLT_AK8PFJet360_TrimMass30||  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20||  HLT_AK8PFJet450||  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200||  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20||  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20||  HLT_PFJet450||  HLT_PFMET120_BTagCSV_p067||  HLT_QuadJet45_DoubleBTagCSV_p087 )',
+        #'2016APV' : '( HLT_QuadJet45_TripleBTagCSV_p087||  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056||  HLT_PFHT450_SixJet40_BTagCSV_p056||  HLT_AK8PFJet360_TrimMass30||  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20||  HLT_AK8PFJet450||  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200||  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20||  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20||  HLT_PFJet450||  HLT_PFMET120_BTagCSV_p067||  HLT_QuadJet45_DoubleBTagCSV_p087 )',
         #'2016APV' : '( HLT_QuadJet45_TripleBTagCSV_p087)',
 #        '2016PostAPV' : '( HLT_QuadJet45_TripleBTagCSV_p087||  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056||  HLT_PFHT450_SixJet40_BTagCSV_p056||  HLT_AK8PFJet360_TrimMass30||  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20||  HLT_AK8PFJet450||  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200||  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20||  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20||  HLT_PFJet450||  HLT_QuadJet45_DoubleBTagCSV_p087 )',
-             '2017' : '(HLT_PFJet450 || HLT_PFJet500 || HLT_PFHT1050 || HLT_AK8PFJet550 || HLT_AK8PFJet360_TrimMass30 || HLT_AK8PFJet400_TrimMass30 || HLT_AK8PFHT750_TrimMass50 || HLT_AK8PFJet330_PFAK8BTagCSV_p17 || HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0 || HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1 || HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 || HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 || HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5 || HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 || HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2 )',
+             #'2017' : '(HLT_PFJet450 || HLT_PFJet500 || HLT_PFHT1050 || HLT_AK8PFJet550 || HLT_AK8PFJet360_TrimMass30 || HLT_AK8PFJet400_TrimMass30 || HLT_AK8PFHT750_TrimMass50 || HLT_AK8PFJet330_PFAK8BTagCSV_p17 || HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0 || HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1 || HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 || HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 || HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5 || HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 || HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2 )',
              #'2017' : '(HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0 )',
              #'2018' : '(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5||HLT_PFHT1050||HLT_PFJet500||HLT_AK8PFJet500||HLT_AK8PFJet400_TrimMass30||HLT_AK8PFHT800_TrimMass50||HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4||HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1||HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2||HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94||HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59||HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17||HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1||HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2|| HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1)',
              #'2018' : '(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5)',
+             '2016APV' : '('+'||'.join([t for t in AllHLTsWithSFs['2016APV']])+')',
+             '2016' : '('+'||'.join([t for t in AllHLTsWithSFs['2016']])+')',
+             '2017' : '('+'||'.join([t for t in AllHLTsWithSFs['2017']])+')',
              '2018' : '('+'||'.join([t for t in AllHLTsWithSFs['2018']])+')',
              '2022' : '('+'||'.join([t for t in AllHLTsWithSFs['2022']])+')',
              '2022EE' : '('+'||'.join([t for t in AllHLTsWithSFs['2022EE']])+')',
@@ -573,6 +625,34 @@ float getTriggerSF( int HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCS
     return triggerSF;
 }
 """
+
+hlt_sf_2016APV = """
+float getTriggerSF( %s ){
+    float triggerSF = 1;
+        if (%s) {triggerSF = 1;}%s
+
+    return triggerSF;
+}
+"""%(', '.join(['int '+t for t in AllHLTsWithSFs['2016APV']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2016APV'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2016APV'].items() if sf!=1.0]))
+
+hlt_sf_2016 = """
+float getTriggerSF( %s ){
+    float triggerSF = 1;
+        if (%s) {triggerSF = 1;}%s
+
+    return triggerSF;
+}
+"""%(', '.join(['int '+t for t in AllHLTsWithSFs['2016']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2016'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2016'].items() if sf!=1.0]))
+
+hlt_sf_2017 = """
+float getTriggerSF( %s ){
+    float triggerSF = 1;
+        if (%s) {triggerSF = 1;}%s
+
+    return triggerSF;
+}
+"""%(', '.join(['int '+t for t in AllHLTsWithSFs['2017']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2017'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2017'].items() if sf!=1.0]))
+
 hlt_sf_2018 = """
 float getTriggerSF( %s ){
     float triggerSF = 1;
@@ -601,12 +681,15 @@ float getTriggerSF( %s ){
 """%(', '.join(['int '+t for t in AllHLTsWithSFs['2022EE']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2022EE'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2022EE'].items() if sf!=1.0]))
 
 
-hlt_method_2016 = 'getTriggerSF( HLT_QuadJet45_TripleBTagCSV_p087,  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056,  HLT_PFHT450_SixJet40_BTagCSV_p056,  HLT_AK8PFJet360_TrimMass30,  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20,  HLT_AK8PFJet450,  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200,  HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq460,  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20,  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20,  HLT_PFJet450,  HLT_QuadJet45_DoubleBTagCSV_p087 );'
+#hlt_method_2016 = 'getTriggerSF( HLT_QuadJet45_TripleBTagCSV_p087,  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056,  HLT_PFHT450_SixJet40_BTagCSV_p056,  HLT_AK8PFJet360_TrimMass30,  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20,  HLT_AK8PFJet450,  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200,  HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq460,  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20,  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20,  HLT_PFJet450,  HLT_QuadJet45_DoubleBTagCSV_p087 );'
 
-hlt_method_2017 = ' getTriggerSF( HLT_PFJet450,  HLT_PFJet500,  HLT_PFHT1050,  HLT_AK8PFJet550,  HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0,  HLT_AK8PFJet360_TrimMass30,  HLT_AK8PFHT750_TrimMass50,  HLT_AK8PFJet400_TrimMass30,  HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1,  HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2,  HLT_AK8PFJet330_PFAK8BTagCSV_p17,  HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2,  HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2,  HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5,  HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 );'
+#hlt_method_2017 = ' getTriggerSF( HLT_PFJet450,  HLT_PFJet500,  HLT_PFHT1050,  HLT_AK8PFJet550,  HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0,  HLT_AK8PFJet360_TrimMass30,  HLT_AK8PFHT750_TrimMass50,  HLT_AK8PFJet400_TrimMass30,  HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1,  HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2,  HLT_AK8PFJet330_PFAK8BTagCSV_p17,  HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2,  HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2,  HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5,  HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 );'
 
 #hlt_method_2018 = ' getTriggerSF(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5,HLT_PFHT1050,HLT_PFJet500,HLT_AK8PFJet500,HLT_AK8PFJet400_TrimMass30,HLT_AK8PFHT800_TrimMass50,HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4,HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1,HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2,HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94,HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59,HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17,HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1,HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2, HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1);'
 
+hlt_method_2016APV = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2016APV']]))
+hlt_method_2016 = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2016']]))
+hlt_method_2017 = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2017']]))
 hlt_method_2018 = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2018']]))
 hlt_method_2022 = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2022']]))
 hlt_method_2022EE = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2022EE']]))
@@ -652,6 +735,9 @@ def addMHHH(df):
     df = df.Define('HHH_mass', 'computeMHHH(0, h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi,h3_t3_mass,h3_t3_pt,h3_t3_eta,h3_t3_phi)')
     df = df.Define('HHH_pt', 'computeMHHH(1, h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi,h3_t3_mass,h3_t3_pt,h3_t3_eta,h3_t3_phi)')
     df = df.Define('HHH_eta', 'computeMHHH(2, h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi,h3_t3_mass,h3_t3_pt,h3_t3_eta,h3_t3_phi)')
+    df = df.Define('HHH4b2tau_mass', 'computeMHHH(0, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi,h3_4b2t_mass,h3_4b2t_pt,h3_4b2t_eta,h3_4b2t_phi)')
+    df = df.Define('HHH4b2tau_pt', 'computeMHHH(1, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi,h3_4b2t_mass,h3_4b2t_pt,h3_4b2t_eta,h3_4b2t_phi)')
+    df = df.Define('HHH4b2tau_eta', 'computeMHHH(2, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi,h3_4b2t_mass,h3_4b2t_pt,h3_4b2t_eta,h3_4b2t_phi)')
     return df
 
 def drawText(x, y, text, color = ROOT.kBlack, fontsize = 0.05, font = 42, doNDC = True, alignment = 12):
@@ -682,7 +768,7 @@ def initialise_df(df,year,proc):
         print('2016 buggy to be fixed in v32')
     if '2022' in year:
         df = df.Define('triggerSF', '1')
-        print("2022 doesn't work and I don't understand why")
+        print("2022 trigger SF doesn't work and I don't understand why")
     else:
         df = df.Define('triggerSF', triggersCorrections[year][1] )
     #cutWeight = '(%f * weight * xsecWeight * l1PreFiringWeight * puWeight * genWeight * triggerSF)'%(lumi)
@@ -786,7 +872,7 @@ def init_get_max_cat():
 
 
 cat = '''
-    int categorisation(int nAK4HiggsReco, int nAK8HiggsReco){
+    int categorisationfunc(int nAK4HiggsReco, int nAK8HiggsReco){
         int ret(0);
 
         // 3 reco Higgs
@@ -817,25 +903,38 @@ ROOT.gInterpreter.Declare(cat)
 
 def matching_variables(df):
     higgsmatched = []
+    higgsmatchedtau = []
     h1match = []
     h2match = []
     h3match = []
+    h1matchtau = []
+    h2matchtau = []
+    h3matchtau = []
     for j in ['jet1','jet2','jet3','jet4','jet5','jet6','jet7','jet8','jet9','jet10']:
         higgsmatched.append('int(%sHiggsMatched)'%j)
         h1match.append('int(%sHiggsMatchedIndex == 1 && %sFatJetMatched == 0)'%(j,j))
         h2match.append('int(%sHiggsMatchedIndex == 2 && %sFatJetMatched == 0)'%(j,j))
         h3match.append('int(%sHiggsMatchedIndex == 3 && %sFatJetMatched == 0)'%(j,j))
+    for t in ['tau1','tau2','tau3','tau4']:
+        higgsmatchedtau.append('int(%sHiggsMatched)'%t)
+        h1matchtau.append('int(%sHiggsMatchedIndex == 1 && %sFatJetMatched == 0)'%(t,t))
+        h2matchtau.append('int(%sHiggsMatchedIndex == 2 && %sFatJetMatched == 0)'%(t,t))
+        h3matchtau.append('int(%sHiggsMatchedIndex == 3 && %sFatJetMatched == 0)'%(t,t))
 
     higgsMatchVar = '+'.join(higgsmatched)
+    higgsMatchVarTau = '+'.join(higgsmatchedtau)
     h1MatchVar = '+'.join(h1match)
     h2MatchVar = '+'.join(h2match)
     h3MatchVar = '+'.join(h3match)
+    h1MatchTauVar = '+'.join(h1matchtau)
+    h2MatchTauVar = '+'.join(h2matchtau)
+    h3MatchTauVar = '+'.join(h3matchtau)
 
     fatjetmatched = []
     fj_h1match = []
     fj_h2match = []
     fj_h3match = []
-    for j in ['fatJet1','fatJet2','fatJet3']:
+    for j in ['fatJet1','fatJet2','fatJet3','fatJet4']:
         fatjetmatched.append('int(%sHiggsMatched)'%j)
         fj_h1match.append('int(%sHiggsMatchedIndex == 1)'%j)
         fj_h2match.append('int(%sHiggsMatchedIndex == 2)'%j)
@@ -847,16 +946,23 @@ def matching_variables(df):
     fj_h3MatchVar = '+'.join(fj_h3match)
 
     df = df.Define('nAK4matched', higgsMatchVar)
+    df = df.Define('nTaumatched', higgsMatchVarTau)
     df = df.Define('nAK8matched', fjMatchVar)
     df = df.Define('h1Match',h1MatchVar)
     df = df.Define('h2Match',h2MatchVar)
     df = df.Define('h3Match',h3MatchVar)
+    df = df.Define('h1MatchTau',h1MatchTauVar)
+    df = df.Define('h2MatchTau',h2MatchTauVar)
+    df = df.Define('h3MatchTau',h3MatchTauVar)
     df = df.Define('fj_h1Match',fj_h1MatchVar)
     df = df.Define('fj_h2Match',fj_h2MatchVar)
     df = df.Define('fj_h3Match',fj_h3MatchVar)
 
     df = df.Define('nAK4HiggsReco', 'int(h1Match >= 2)+ int(h2Match >= 2)+ int(h3Match >= 2)')
+    df = df.Define('nAK4onlyHiggsReco', 'int(h1Match >= 2)*int(h1MatchTau < 2)+ int(h2Match >= 2)*int(h2MatchTau < 2)+ int(h3Match >= 2)*int(h3MatchTau < 2)')
+    df = df.Define('nTauHiggsReco', 'int(h1MatchTau >= 2)+ int(h2MatchTau >= 2)+ int(h3MatchTau >= 2)')
     df = df.Define('nAK8HiggsReco', 'int(fj_h1Match >= 1)+ int(fj_h2Match >= 1)+ int(fj_h3Match >= 1)')
-    df = df.Define('categorisation','categorisation( nAK4HiggsReco,nAK8HiggsReco)')
+    df = df.Define('categorisation','categorisationfunc( nAK4HiggsReco,nAK8HiggsReco)')
+    df = df.Define('categorisation4b2tau','categorisationfunc( nAK4onlyHiggsReco+nTauHiggsReco,nAK8HiggsReco)')
 
     return df

--- a/utils.py
+++ b/utils.py
@@ -335,6 +335,7 @@ histograms_dict = {
 #doing this ordered dictionary to make sure of the drawing order
 # [color, marker size, line size, legend label , add in legend]
 hist_properties = {'JetHT' : [ROOT.kBlack, 0.8, 0, 'Data', True] ,
+                   'JetMET' : [ROOT.kBlack, 0.8, 0, 'Data', True],
                    'JetHT-btagSF' : [ROOT.kBlack, 0.8, 0, 'Data', True],
                    'BTagCSV' : [ROOT.kBlack, 0.8, 0, 'Data', True],
                    'data_obs' : [ROOT.kBlack, 0.8, 0, 'Data', True],
@@ -727,8 +728,28 @@ computeMHHH = '''
 
 '''
 
+computeMHH = '''
+    float computeMHH(int type, float h1_t3_mass, float h1_t3_pt, float h1_t3_eta, float h1_t3_phi,float h2_t3_mass, float h2_t3_pt, float h2_t3_eta, float h2_t3_phi) {
+        TLorentzVector h1;
+        TLorentzVector h2;
+
+        h1.SetPtEtaPhiM(h1_t3_pt, h1_t3_eta, h1_t3_phi, h1_t3_mass);
+        h2.SetPtEtaPhiM(h2_t3_pt, h2_t3_eta, h2_t3_phi, h2_t3_mass);
+
+        if (type == 0)
+            return (h1+h2).M();
+        else if (type == 1)
+            return (h1+h2).Pt();
+        else if (type == 2)
+            return (h1+h2).Eta();
+        else return 0;
+    }
+
+'''
+
 def init_mhhh():
     ROOT.gInterpreter.Declare(computeMHHH)
+    ROOT.gInterpreter.Declare(computeMHH)
 
 def addMHHH(df):
     df = df.Define('mHHH', 'computeMHHH(0,h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi,h3_t3_mass,h3_t3_pt,h3_t3_eta,h3_t3_phi)') # for compatibility with boosted BDT
@@ -738,6 +759,12 @@ def addMHHH(df):
     df = df.Define('HHH4b2tau_mass', 'computeMHHH(0, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi,h3_4b2t_mass,h3_4b2t_pt,h3_4b2t_eta,h3_4b2t_phi)')
     df = df.Define('HHH4b2tau_pt', 'computeMHHH(1, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi,h3_4b2t_mass,h3_4b2t_pt,h3_4b2t_eta,h3_4b2t_phi)')
     df = df.Define('HHH4b2tau_eta', 'computeMHHH(2, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi,h3_4b2t_mass,h3_4b2t_pt,h3_4b2t_eta,h3_4b2t_phi)')
+    df = df.Define('HH_mass', 'computeMHH(0, h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi)')
+    df = df.Define('HH_pt', 'computeMHH(1, h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi)')
+    df = df.Define('HH_eta', 'computeMHH(2, h1_t3_mass,h1_t3_pt,h1_t3_eta,h1_t3_phi,h2_t3_mass,h2_t3_pt,h2_t3_eta,h2_t3_phi)')
+    df = df.Define('HH4b2tau_mass', 'computeMHH(0, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi)')
+    df = df.Define('HH4b2tau_pt', 'computeMHH(1, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi)')
+    df = df.Define('HH4b2tau_eta', 'computeMHH(2, h1_4b2t_mass,h1_4b2t_pt,h1_4b2t_eta,h1_4b2t_phi,h2_4b2t_mass,h2_4b2t_pt,h2_4b2t_eta,h2_4b2t_phi)')
     return df
 
 def drawText(x, y, text, color = ROOT.kBlack, fontsize = 0.05, font = 42, doNDC = True, alignment = 12):
@@ -773,7 +800,7 @@ def initialise_df(df,year,proc):
         df = df.Define('triggerSF', triggersCorrections[year][1] )
     #cutWeight = '(%f * weight * xsecWeight * l1PreFiringWeight * puWeight * genWeight * triggerSF)'%(lumi)
     cutWeight = '(%f * xsecWeight * l1PreFiringWeight * puWeight * genWeight * triggerSF)'%(lumi)
-    if 'JetHT' in proc or 'BTagCSV' in proc or 'SingleMuon' in proc:
+    if 'JetHT' in proc or 'JetMET' in proc or 'BTagCSV' in proc or 'SingleMuon' in proc:
         df = df.Define('eventWeight','1')
     else:
         df = df.Define('eventWeight',cutWeight)
@@ -801,9 +828,10 @@ def initialise_df(df,year,proc):
     df = df.Define('nmediumbtags',nmedium)
     df = df.Define('ntightbtags',ntight)
 
-    df = addBTagEffSF(df,proc,'loose')
-    df = addBTagEffSF(df,proc,'medium')
-    df = addBTagEffSF(df,proc,'tight')
+    if not ('JetHT' in proc or 'JetMET' in proc or 'BTagCSV' in proc or 'SingleMuon' in proc):
+        df = addBTagEffSF(df,proc,'loose')
+        df = addBTagEffSF(df,proc,'medium')
+        df = addBTagEffSF(df,proc,'tight')
 
     return df
 
@@ -915,7 +943,7 @@ def matching_variables(df):
         h1match.append('int(%sHiggsMatchedIndex == 1 && %sFatJetMatched == 0)'%(j,j))
         h2match.append('int(%sHiggsMatchedIndex == 2 && %sFatJetMatched == 0)'%(j,j))
         h3match.append('int(%sHiggsMatchedIndex == 3 && %sFatJetMatched == 0)'%(j,j))
-    for t in ['tau1','tau2','tau3','tau4']:
+    for t in ['tau1','tau2','tau3','tau4','lep1','lep2','lep3','lep4']:
         higgsmatchedtau.append('int(%sHiggsMatched)'%t)
         h1matchtau.append('int(%sHiggsMatchedIndex == 1 && %sFatJetMatched == 0)'%(t,t))
         h2matchtau.append('int(%sHiggsMatchedIndex == 2 && %sFatJetMatched == 0)'%(t,t))

--- a/utils.py
+++ b/utils.py
@@ -7,12 +7,55 @@ import ROOT
 q = random.uniform(0,1)
 
 luminosities = {#'2016' : 36330.0,
-                '2016APV' : 19207.0,
-                '2016PostAPV' : 17122.0,
-                '2016' : 17122.0,
+                '2016APV' : 19520.0,
+                '2016PostAPV' : 16810.0,
+                '2016' : 16810.0,
                 '2017' : 41480.0,
                 '2018' : 59830.0,
+                '2022' : 7880.0,
+                '2022EE' : 26340.0,
         }
+
+
+# Nice list to construct "hlt_paths", "hlt_sf_20XX" and "hlt_method_20XX" from.
+# Currently only made for 2018/2022/2022EE
+AllHLTsWithSFs = {
+    '2018': {
+        'HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5': 1.0,
+        'HLT_PFHT1050': 1.0,
+        'HLT_PFJet500': 1.0,
+        'HLT_AK8PFJet500': 1.0,
+        'HLT_AK8PFJet400_TrimMass30': 1.0,
+        'HLT_AK8PFHT800_TrimMass50': 1.0,
+        'HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4': 54.44/59.74,
+        'HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1': 54.44/59.74,
+        'HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2': 54.44/59.74,
+        'HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94': 42.28/59.96,
+        'HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59': 42.28/59.96,
+        'HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17': 22.74/59.96,
+        'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1': 9.25/59.96,
+        'HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2': 9.25/59.96,
+        'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1': 1.41/59.96,
+    },
+    '2022': {
+        'HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepJet_4p5': 1.0,
+        'HLT_PFHT1050': 1.0,
+        'HLT_PFJet500': 1.0,
+        'HLT_AK8PFJet500': 1.0,
+        'HLT_AK8PFJet400_TrimMass30': 1.0,
+        'HLT_AK8PFHT800_TrimMass50': 1.0,
+        'HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4': 1.0,
+        'HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepJet_1p3_7p7_VBF1': 1.0,
+        'HLT_QuadPFJet103_88_75_15_PFBTagDeepJet_1p3_VBF2': 1.0,
+        'HLT_PFHT400_SixPFJet32_DoublePFBTagDeepJet_2p94': 1.0,
+        'HLT_PFHT450_SixPFJet36_PFBTagDeepJet_1p59': 1.0,
+        'HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17': 1.0,
+        'HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepJet_1p3_7p7_VBF1': 1.0,
+        'HLT_QuadPFJet98_83_71_15_PFBTagDeepJet_1p3_VBF2': 1.0,
+        'HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1': 1.0,
+    }
+}
+AllHLTsWithSFs['2022EE'] = AllHLTsWithSFs['2022']
 
 
 hlt_paths = {
@@ -24,8 +67,11 @@ hlt_paths = {
 #        '2016PostAPV' : '( HLT_QuadJet45_TripleBTagCSV_p087||  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056||  HLT_PFHT450_SixJet40_BTagCSV_p056||  HLT_AK8PFJet360_TrimMass30||  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20||  HLT_AK8PFJet450||  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200||  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20||  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20||  HLT_PFJet450||  HLT_QuadJet45_DoubleBTagCSV_p087 )',
              '2017' : '(HLT_PFJet450 || HLT_PFJet500 || HLT_PFHT1050 || HLT_AK8PFJet550 || HLT_AK8PFJet360_TrimMass30 || HLT_AK8PFJet400_TrimMass30 || HLT_AK8PFHT750_TrimMass50 || HLT_AK8PFJet330_PFAK8BTagCSV_p17 || HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0 || HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1 || HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 || HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 || HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5 || HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 || HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2 )',
              #'2017' : '(HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0 )',
-             '2018' : '(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5||HLT_PFHT1050||HLT_PFJet500||HLT_AK8PFJet500||HLT_AK8PFJet400_TrimMass30||HLT_AK8PFHT800_TrimMass50||HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4||HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1||HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2||HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94||HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59||HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17||HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1||HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2|| HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1)',
+             #'2018' : '(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5||HLT_PFHT1050||HLT_PFJet500||HLT_AK8PFJet500||HLT_AK8PFJet400_TrimMass30||HLT_AK8PFHT800_TrimMass50||HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4||HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1||HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2||HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94||HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59||HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17||HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1||HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2|| HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1)',
              #'2018' : '(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5)',
+             '2018' : '('+'||'.join([t for t in AllHLTsWithSFs['2018']])+')',
+             '2022' : '('+'||'.join([t for t in AllHLTsWithSFs['2022']])+')',
+             '2022EE' : '('+'||'.join([t for t in AllHLTsWithSFs['2022EE']])+')',
         }
 
 
@@ -368,14 +414,14 @@ def clean_variables(variables) :
 
 
 # 2018
-wps = { 'loose'  : '0.0490',
-        'medium' : '0.2783',
-        'tight'  : '0.7100',
-        }
+#wps = { 'loose'  : '0.0490',
+#        'medium' : '0.2783',
+#        'tight'  : '0.7100',
+#        }
 
-wps_years = { 'loose' : {'2016APV': 0.0508, '2016': 0.0480, '2016PostAPV': 0.0480, '2017': 0.0532, '2018': 0.0490},
-              'medium': {'2016APV': 0.2598, '2016': 0.2489, '2016PostAPV': 0.2489, '2017': 0.3040, '2018': 0.2783},
-              'tight' : {'2016APV': 0.6502, '2016': 0.6377, '2016PostAPV': 0.6377, '2017': 0.7476, '2018': 0.7100},
+wps_years = { 'loose' : {'2016APV': 0.0508, '2016': 0.0480, '2016PostAPV': 0.0480, '2017': 0.0532, '2018': 0.0490, '2022': 0.0583, '2022EE': 0.0614},
+              'medium': {'2016APV': 0.2598, '2016': 0.2489, '2016PostAPV': 0.2489, '2017': 0.3040, '2018': 0.2783, '2022': 0.3086, '2022EE': 0.3196},
+              'tight' : {'2016APV': 0.6502, '2016': 0.6377, '2016PostAPV': 0.6377, '2017': 0.7476, '2018': 0.7100, '2022': 0.7183, '2022EE': 0.7300},
         }
 
 label_dict = {'L': [wps_years['loose'],'Loose'],
@@ -527,21 +573,54 @@ float getTriggerSF( int HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCS
     return triggerSF;
 }
 """
+hlt_sf_2018 = """
+float getTriggerSF( %s ){
+    float triggerSF = 1;
+        if (%s) {triggerSF = 1;}%s
 
+    return triggerSF;
+}
+"""%(', '.join(['int '+t for t in AllHLTsWithSFs['2018']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2018'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2018'].items() if sf!=1.0]))
 
+hlt_sf_2022 = """
+float getTriggerSF( %s ){
+    float triggerSF = 1;
+        if (%s) {triggerSF = 1;}%s
+
+    return triggerSF;
+}
+"""%(', '.join(['int '+t for t in AllHLTsWithSFs['2022']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2022'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2022'].items() if sf!=1.0]))
+
+hlt_sf_2022EE = """
+float getTriggerSF( %s ){
+    float triggerSF = 1;
+        if (%s) {triggerSF = 1;}%s
+
+    return triggerSF;
+}
+"""%(', '.join(['int '+t for t in AllHLTsWithSFs['2022EE']]), ' || '.join([t for t,sf in AllHLTsWithSFs['2022EE'].items() if sf==1.0]), ''.join(['\n        else if ('+t+') {triggerSF = '+str(sf)+';}' for t,sf in AllHLTsWithSFs['2022EE'].items() if sf!=1.0]))
 
 
 hlt_method_2016 = 'getTriggerSF( HLT_QuadJet45_TripleBTagCSV_p087,  HLT_PFHT400_SixJet30_DoubleBTagCSV_p056,  HLT_PFHT450_SixJet40_BTagCSV_p056,  HLT_AK8PFJet360_TrimMass30,  HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV_p20,  HLT_AK8PFJet450,  HLT_QuadPFJet_BTagCSV_p016_p11_VBF_Mqq200,  HLT_QuadPFJet_BTagCSV_p016_VBF_Mqq460,  HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20,  HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV_p20,  HLT_PFJet450,  HLT_QuadJet45_DoubleBTagCSV_p087 );'
 
 hlt_method_2017 = ' getTriggerSF( HLT_PFJet450,  HLT_PFJet500,  HLT_PFHT1050,  HLT_AK8PFJet550,  HLT_PFHT300PT30_QuadPFJet_75_60_45_40_TriplePFBTagCSV_3p0,  HLT_AK8PFJet360_TrimMass30,  HLT_AK8PFHT750_TrimMass50,  HLT_AK8PFJet400_TrimMass30,  HLT_PFMET100_PFMHT100_IDTight_CaloBTagCSV_3p1,  HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2,  HLT_AK8PFJet330_PFAK8BTagCSV_p17,  HLT_QuadPFJet98_83_71_15_BTagCSV_p013_VBF2,  HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2,  HLT_PFHT430_SixPFJet40_PFBTagCSV_1p5,  HLT_QuadPFJet98_83_71_15_DoubleBTagCSV_p013_p08_VBF1 );'
 
-hlt_method_2018 = ' getTriggerSF(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5,HLT_PFHT1050,HLT_PFJet500,HLT_AK8PFJet500,HLT_AK8PFJet400_TrimMass30,HLT_AK8PFHT800_TrimMass50,HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4,HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1,HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2,HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94,HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59,HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17,HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1,HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2, HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1);'
+#hlt_method_2018 = ' getTriggerSF(HLT_PFHT330PT30_QuadPFJet_75_60_45_40_TriplePFBTagDeepCSV_4p5,HLT_PFHT1050,HLT_PFJet500,HLT_AK8PFJet500,HLT_AK8PFJet400_TrimMass30,HLT_AK8PFHT800_TrimMass50,HLT_AK8PFJet330_TrimMass30_PFAK8BoostedDoubleB_np4,HLT_QuadPFJet103_88_75_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1,HLT_QuadPFJet103_88_75_15_PFBTagDeepCSV_1p3_VBF2,HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94,HLT_PFHT450_SixPFJet36_PFBTagDeepCSV_1p59,HLT_AK8PFJet330_TrimMass30_PFAK8BTagDeepCSV_p17,HLT_QuadPFJet98_83_71_15_DoublePFBTagDeepCSV_1p3_7p7_VBF1,HLT_QuadPFJet98_83_71_15_PFBTagDeepCSV_1p3_VBF2, HLT_PFMET100_PFMHT100_IDTight_CaloBTagDeepCSV_3p1);'
+
+hlt_method_2018 = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2018']]))
+hlt_method_2022 = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2022']]))
+hlt_method_2022EE = 'getTriggerSF(%s);'%(','.join([t for t in AllHLTsWithSFs['2022EE']]))
+
+
 
 
 triggersCorrections = {
+                       '2016APV' : [hlt_sf_2016,hlt_method_2016],
                        '2016' : [hlt_sf_2016,hlt_method_2016],
                        '2017' : [hlt_sf_2017,hlt_method_2017],
                        '2018' : [hlt_sf_2018,hlt_method_2018],
+                       '2022' : [hlt_sf_2022,hlt_method_2022],
+                       '2022EE' : [hlt_sf_2022EE,hlt_method_2022EE],
         }
 
 computeMHHH = '''
@@ -601,6 +680,9 @@ def initialise_df(df,year,proc):
         #df = df.Define('triggerSF', triggersCorrections['2016'][1] )
         df = df.Define('triggerSF', '1')
         print('2016 buggy to be fixed in v32')
+    if '2022' in year:
+        df = df.Define('triggerSF', '1')
+        print("2022 doesn't work and I don't understand why")
     else:
         df = df.Define('triggerSF', triggersCorrections[year][1] )
     #cutWeight = '(%f * weight * xsecWeight * l1PreFiringWeight * puWeight * genWeight * triggerSF)'%(lumi)


### PR DESCRIPTION
- Make some paths point to $CMSSW_BASE instead of "/isilon/..."
- Options for 2022/2022EE
- Add function that adds "1.0" for variables that don't exist in Run3 (jetXbRegCorr) but are needed in some parts of the code
- Improved `prepare_jobs.py`:
  * Works for lxplus
  * Can be run many times: Will resubmit previously failed jobs, or move on to run the second command
  * Will say when all jobs are done
  * NOTE: The workflow was also slightly changed: For the first script `predict_spanet_classification_pnet_all_vars.py` samples will be split, but no change is expected between that output and the input for the second script `predict_spanet_classification_categorisation.py`. Re-hadding with `merge_samples.py` should be done only once at the end of running the second script
- Added more arguments / less hardcoded paths to some scripts
- Some other small fixes